### PR TITLE
Fix MCP download error

### DIFF
--- a/nova.ps1
+++ b/nova.ps1
@@ -82,7 +82,7 @@ function New-NovaEnvironment {
 
     # Download MCP
     $wc = New-Object System.Net.WebClient
-    $wc.DownloadFile("http://www.modcoderpack.com/website/sites/default/files/releases/mcp931.zip", "$PSScriptRoot/mcp/mcp.zip")
+    $wc.DownloadFile("http://www.modcoderpack.com/files/mcp931.zip", "$PSScriptRoot/mcp/mcp.zip")
 
     # Extract MCP
     Unzip -zipfile "$PSScriptRoot/mcp/mcp.zip" -outpath "$PSScriptRoot/mcp/"

--- a/nova.sh
+++ b/nova.sh
@@ -27,7 +27,7 @@ setup_nova() {
 
     echo "Downloading MCP"
     rm -rf mcp && mkdir mcp && (cd mcp
-        wget http://www.modcoderpack.com/website/sites/default/files/releases/mcp931.zip && unzip mcp931.zip
+        wget http://www.modcoderpack.com/files/mcp931.zip && unzip mcp931.zip
         rm -f mcp*.zip
 
         echo "Decompile MCP"


### PR DESCRIPTION
Fixes the "Exception calling "DownloadFile" with "2" argument(s): "The remote server returned an error: (404) Not Found."" error that occurs trying to download the MCP