### PR TITLE
Fixed parameters for MCP commands (setup.gradle)

### DIFF
--- a/setup.gradle
+++ b/setup.gradle
@@ -92,9 +92,9 @@ task decompileMcp(dependsOn: downloadMcp) {
                     workingDir './mcp'
                 } else {
                     if(System.properties.contains("MCP_LOC")) {
-                        commandLine 'python2', '${project.projectDir}/mcp/runtime/decompile.py', '-m', System.properties.getProperty("MCP_LOC")
+                        commandLine 'python2', "${project.projectDir}/mcp/runtime/decompile.py", '-m', System.properties.getProperty("MCP_LOC")
                     } else {
-                        commandLine 'python2', '${project.projectDir}/mcp/runtime/decompile.py'
+                        commandLine 'python2', "${project.projectDir}/mcp/runtime/decompile.py"
                     }
                     workingDir 'mcp'
                 }


### PR DESCRIPTION
The template strings only work with double quotes, so I had to change those parameters to use double quotes in order for it to properly run MCP. 

I kept fixing this manually every time I cloned the project and I figured I might as well finally get around to creating a PR :P