### PR TITLE
Removed RenderDoc submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,9 +16,6 @@
 [submodule "src/main/cpp/3rdparty/optional"]
 	path = src/main/cpp/3rdparty/optional
 	url = https://github.com/akrzemi1/Optional.git
-[submodule "src/main/cpp/3rdparty/renderdocapi"]
-	path = src/main/cpp/3rdparty/renderdocapi
-	url = https://github.com/NovaMods/RenderDoc-Manager.git
 [submodule "src/main/cpp/3rdparty/VulkanMemoryAllocator"]
 	path = src/main/cpp/3rdparty/VulkanMemoryAllocator
 	url = https://github.com/GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator.git


### PR DESCRIPTION
Fixed issue where `gradlew setup` would fail because the `renderdocapi` reference commit has been deleted.