### PR TITLE
Use __has_include to include std::*::filesystem conditionally

### DIFF
--- a/src/loading/folder_accessor.hpp
+++ b/src/loading/folder_accessor.hpp
@@ -8,21 +8,11 @@
 
 #include <string>
 #include <vector>
-#include <filesystem>
 #include <unordered_map>
 #include <optional>
+#include "../util/filesystem.hpp"
 #include "../util/utils.hpp"
 #include <mutex>
-
-#if NOVA_WINDOWS
-    #if _MSC_VER <= 1915
-        namespace fs = std::experimental::filesystem;
-    #else
-        namespace fs = std::filesystem;
-    #endif
-#else
-    namespace fs = std::filesystem;
-#endif
 
 namespace nova {
     NOVA_EXCEPTION(resource_not_found_exception);

--- a/src/loading/loading_utils.hpp
+++ b/src/loading/loading_utils.hpp
@@ -7,17 +7,8 @@
 #define NOVA_RENDERER_LOADING_UTILS_HPP
 
 #include <string>
-#include <filesystem>
 
-#if NOVA_WINDOWS
-    #if _MSC_VER <= 1915
-        namespace fs = std::experimental::filesystem;
-    #else
-        namespace fs = std::filesystem;
-    #endif
-#else
-    namespace fs = std::filesystem;
-#endif
+#include "../util/filesystem.hpp"
 
 namespace nova {
     /*!

--- a/src/loading/shaderpack/shaderpack_data.hpp
+++ b/src/loading/shaderpack/shaderpack_data.hpp
@@ -13,23 +13,13 @@
 #include <unordered_map>
 #include <cstdint>
 #include <optional>
-#include <filesystem>
 #include <nlohmann/json.hpp>
+#include "../../util/filesystem.hpp"
 #include "../../util/utils.hpp"
 
 #include <vulkan/vulkan.h>
 
 #include <glm/glm.hpp>
-
-#if NOVA_WINDOWS
-#if _MSC_VER <= 1915
-namespace fs = std::experimental::filesystem;
-#else
-namespace fs = std::filesystem;
-#endif
-#else
-namespace fs = std::filesystem;
-#endif
 
 namespace nova {
     NOVA_EXCEPTION(validation_failure_exception);

--- a/src/loading/shaderpack/shaderpack_loading.hpp
+++ b/src/loading/shaderpack/shaderpack_loading.hpp
@@ -8,19 +8,7 @@
 
 #include "shaderpack_data.hpp"
 #include <future>
-
-#if NOVA_WINDOWS
-    #if _MSC_VER <= 1915
-        #include <experimental/filesystem>
-        namespace fs = std::experimental::filesystem;
-    #else
-        #include <filesystem>
-        namespace fs = std::filesystem;
-    #endif
-#else
-    #include <filesystem>
-    namespace fs = std::filesystem;
-#endif
+#include "../../util/filesystem.hpp"
 
 namespace nova {
     namespace ttl {

--- a/src/util/filesystem.hpp
+++ b/src/util/filesystem.hpp
@@ -1,0 +1,17 @@
+/*!
+ * \author cwfitzgerald
+ * \date 27-Jan-19.
+ */
+
+#ifndef NOVA_RENDERER_FILESYSTEM_UTIL_HPP
+#define NOVA_RENDERER_FILESYSTEM_UTIL_HPP
+
+#if __has_include(<filesystem>)
+#include <filesystem>
+namespace fs = std::filesystem;
+#else
+#include <experimental/filesystem>
+namespace fs = std::experimental::filesystem;
+#endif
+
+#endif

--- a/src/util/utils.hpp
+++ b/src/util/utils.hpp
@@ -15,17 +15,7 @@
 
 #include <fstream>
 
-#include <filesystem>
-
-#if NOVA_WINDOWS
-    #if _MSC_VER <= 1915
-        namespace fs = std::experimental::filesystem;
-    #else
-        namespace fs = std::filesystem;
-    #endif
-#else
-    namespace fs = std::filesystem;
-#endif
+#include "filesystem.hpp"
 
 namespace nova {
     template<int Num>


### PR DESCRIPTION
Unified filesystem include logic to its own header. Used __has_include to test if header exists.