### PR TITLE
Turn off -Werror within SPIRV-tools

### DIFF
--- a/3rdparty/3rdparty.cmake
+++ b/3rdparty/3rdparty.cmake
@@ -36,6 +36,7 @@ set_target_properties(spirv::headers PROPERTIES
     INTERFACE_COMPILE_FEATURES cxx_std_17
 )
 set(SPIRV-Headers_SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/SPIRV-Headers)
+set(SPIRV_WERROR OFF CACHE BOOL "Enable error on warning SPIRV-Tools" FORCE)
 add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/SPIRV-Tools)
 add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/glslang)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -192,16 +192,16 @@ set(COMMON_LINK_LIBS ${CMAKE_DL_LIBS}
                      SPIRV
                      ${SPIRV_SHARED_LIBRARIES}
                      ${Vulkan_LIBRARIES})
+include(CheckCXXCompilerFlag)
 if(WIN32)
     find_package(WindowsSDK)
     get_windowssdk_include_dirs(${WINDOWSSDK_LATEST_DIR} WinSDK_DIRS)
 
     # MSVC 15.9 broke the Windows SDK by implementing two phase lookup. "/Zc:twoPhase-" disables it.
 
-    include(CheckCXXCompilerFlag)
-    CHECK_CXX_COMPILER_FLAG(/Zc:twoPhase- HAS_TWO_PHASE_LOOKUP)
-    if (HAS_TWO_PHASE_LOOKUP)
-        add_definitions(/Zc:twoPhase-)
+    CHECK_CXX_COMPILER_FLAG(/Zc:twoPhase- TWO_PHASE_LOOKUP)
+    if (TWO_PHASE_LOOKUP)
+        add_compile_options(/Zc:twoPhase-)
     endif()
 
     set_target_properties(nova-renderer PROPERTIES PREFIX "")
@@ -218,6 +218,13 @@ if(WIN32)
     endforeach()
     
 else()
+    # GCC and Clang complain loudly about the #pragma region stuff. This shuts them up.
+
+    CHECK_CXX_COMPILER_FLAG(-Wno-unknown-pragmas Wno_unknown_pragmas)
+    if (Wno_unknown_pragmas)
+        add_compile_options(-Wno-unknown-pragmas)
+    endif()
+
     set(COMMON_LINK_LIBS ${COMMON_LINK_LIBS} stdc++fs X11)
 endif()
 


### PR DESCRIPTION
SPIRV-Tools triggers a warning on travis that I can't seem to replicate, but either way, having it set to -Werror sounds like a very bad and annoying idea. This disables it.

Monitor: https://travis-ci.org/BVE-Reborn/bve-reborn/builds/485219863
Jobs: https://travis-ci.org/BVE-Reborn/bve-reborn/jobs/485219865 and https://travis-ci.org/BVE-Reborn/bve-reborn/jobs/485219866