### PR TITLE
Remove /permissive- from builds due to interference with old windows SDKs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS ON)
 if(NOT ${NOVA_IN_SUBMODULE})
     set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
     set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
@@ -48,6 +49,8 @@ include(${3RD_PARTY_DIR}/3rdparty.cmake)
 ######################################
 # Make dependencies' headers visible #
 ######################################
+
+include(cmake/RemovePermissive.cmake)
 
 include_directories(SYSTEM
         $ENV{VULKAN_SDK}/include
@@ -217,6 +220,11 @@ if(WIN32)
         add_compile_options(/Zc:twoPhase-)
     endif()
 
+    CHECK_CXX_COMPILER_FLAG(/permissive PERMISSIVE)
+    if (PERMISSIVE)
+        add_compile_options(/permissive)
+    endif()
+
     set_target_properties(nova-renderer PROPERTIES PREFIX "")
     set(COMMON_LINK_LIBS ${COMMON_LINK_LIBS} d3d12 dxgi d3dcompiler)
     target_include_directories(nova-renderer PRIVATE ${WinSDK_DIRS})
@@ -241,6 +249,10 @@ else()
 endif()
 
 target_link_libraries(nova-renderer ${COMMON_LINK_LIBS})
+
+remove_permissive(nova-renderer)
+get_target_property(FLAGS nova-renderer COMPILE_OPTIONS)
+message(STATUS "${FLAGS}")
 
 set(NOVA_TEST ON)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -251,8 +251,6 @@ endif()
 target_link_libraries(nova-renderer ${COMMON_LINK_LIBS})
 
 remove_permissive(nova-renderer)
-get_target_property(FLAGS nova-renderer COMPILE_OPTIONS)
-message(STATUS "${FLAGS}")
 
 set(NOVA_TEST ON)
 

--- a/cmake/RemovePermissive.cmake
+++ b/cmake/RemovePermissive.cmake
@@ -1,0 +1,5 @@
+function(remove_permissive TARGET)
+    get_target_property(FLAGS ${TARGET} COMPILE_OPTIONS)
+    string(REPLACE "/permissive-" "/permissive" OUT_FLAGS "${FLAGS}")
+    set_property(TARGET ${TARGET} PROPERTY COMPILE_OPTIONS ${OUT_FLAGS})
+endfunction()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -14,6 +14,7 @@ target_compile_definitions(nova-test-end-to-end PRIVATE CMAKE_DEFINED_RESOURCES_
 target_link_libraries(nova-test-end-to-end PRIVATE nova-renderer gtest gtest_main Threads::Threads)
 
 add_test(NAME nova-end-to-end-test COMMAND nova-test-end-to-end)
+remove_permissive(nova-test-end-to-end)
 
 # Unit tests
 add_executable(nova-test-unit unit_tests/loading/filesystem_test.cpp src/general_test_setup.hpp unit_tests/loading/shaderpack/shaderpack_validator_tests.cpp)
@@ -22,6 +23,7 @@ target_link_libraries(nova-test-unit nova-renderer gtest gtest_main Threads::Thr
 
 gtest_discover_tests(nova-test-unit)
 add_test(NAME nova-unit-tests COMMAND nova-test-unit)
+remove_permissive(nova-test-unit)
 
 set(CMAKE_CXX_FLAGS "${NOVA_CXX_FLAGS}")
 


### PR DESCRIPTION
As title says, this was the blocking issue for AppVeyor