### PR TITLE
Guard CCache behind a Variable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,8 +24,10 @@ if(NOT ${NOVA_IN_SUBMODULE})
     set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 endif()
 
-include(CCache)
-include(ClangFormat)
+if(NOVA_CCACHE)
+    include(CCache)
+    include(ClangFormat)
+endif()
 
 set(CMAKE_INSTALL_PREFIX ${CMAKE_CURRENT_LIST_DIR}/build)
 


### PR DESCRIPTION
The "normal" way of turning on CCache is through either using a ccache link as the compiler, or by asking cmake to use ccache as the compiler runner. Either of these combined with ccache autodetection cause ccache to recurse, making it very unhappy.