### PR TITLE
Cmake fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -185,8 +185,6 @@ set(3RD_PARTY_SOURCE
 ##########################################
 if (UNIX)
     add_compile_options_if_supported(-g -fno-omit-frame-pointer -fPIC -fdiagnostics-color=always)
-    # TODO: Find a CMake 3.12-compatible way to do this
-    # add_link_options(-fno-omit-frame-pointer)
 endif()
 
 if(NOVA_TREAT_WARNINGS_AS_ERRORS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -311,6 +311,7 @@ if (CMAKE_BUILD_TYPE STREQUAL "Debug" AND NOT NOVA_IN_SUBMODULE)
     set(NOVA_TEST ON)
 endif()
 
+set(NOVA_TEST ON)
 if(NOVA_TEST)
     add_subdirectory(tests)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.13)
+cmake_minimum_required(VERSION 3.10)
 project(nova-renderer)
 
 ################################################################
@@ -185,7 +185,8 @@ set(3RD_PARTY_SOURCE
 ##########################################
 if (UNIX)
     add_compile_options_if_supported(-g -fno-omit-frame-pointer -fPIC -fdiagnostics-color=always)
-    add_link_options(-fno-omit-frame-pointer)
+    # TODO: Find a CMake 3.12-compatible way to do this
+    # add_link_options(-fno-omit-frame-pointer)
 endif()
 
 if(NOVA_TREAT_WARNINGS_AS_ERRORS)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,6 @@ platform:
   - x64
 
 clone_folder: c:\projects\nova-renderer
-clone_depth: 1
 skip_tags: true
 
 environment:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,3 +36,11 @@ build:
 test_script:
 - cmd: dir C:\projects\nova-renderer\build\%CONFIGURATION%\
 - cmd: C:\projects\nova-renderer\build\%CONFIGURATION%\nova-test-unit.exe
+
+on_success:
+  - ps: Invoke-RestMethod https://raw.githubusercontent.com/DiscordHooks/appveyor-discord-webhook/master/send.ps1 -o send.ps1
+  - ps: ./send.ps1 success $env:WEBHOOK_URL
+on_failure:
+  - ps: Invoke-RestMethod https://raw.githubusercontent.com/DiscordHooks/appveyor-discord-webhook/master/send.ps1 -o send.ps1
+  - ps: ./send.ps1 failure $env:WEBHOOK_URL
+  

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -43,4 +43,3 @@ on_success:
 on_failure:
   - ps: Invoke-RestMethod https://raw.githubusercontent.com/DiscordHooks/appveyor-discord-webhook/master/send.ps1 -o send.ps1
   - ps: ./send.ps1 failure $env:WEBHOOK_URL
-  

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -28,7 +28,7 @@ find_package(Threads REQUIRED)
 add_executable(nova-test-end-to-end src/end_to_end_runner.cpp src/general_test_setup.hpp)
 target_compile_definitions(nova-test-end-to-end PRIVATE CMAKE_DEFINED_RESOURCES_PREFIX="${CMAKE_CURRENT_LIST_DIR}/resources/")
 target_compile_options_if_supported(nova-test-end-to-end PRIVATE -Wno-unknown-pragmas)
-target_link_libraries(nova-test-end-to-end PRIVATE nova-renderer gtest gtest_main Threads::Threads)
+target_link_libraries(nova-test-end-to-end PRIVATE nova-renderer Threads::Threads)
 remove_permissive(nova-test-end-to-end)
 
 ##############
@@ -36,11 +36,23 @@ remove_permissive(nova-test-end-to-end)
 ##############
 add_executable(nova-test-unit unit_tests/loading/filesystem_test.cpp src/general_test_setup.hpp unit_tests/loading/shaderpack/shaderpack_validator_tests.cpp)
 target_compile_definitions(nova-test-unit PRIVATE CMAKE_DEFINED_RESOURCES_PREFIX="${CMAKE_CURRENT_LIST_DIR}/resources/")
-target_link_libraries(nova-test-unit nova-renderer gtest gtest_main Threads::Threads)
+target_link_libraries(nova-test-unit nova-renderer gtest_main Threads::Threads)
 target_compile_options_if_supported(nova-test-unit PRIVATE -Wno-unknown-pragmas)
 remove_permissive(nova-test-unit)
 
 # Reset shared libraries option if changed by us
 if(DEFINED BUILD_SHARED_LIBS_ORIGINAL_NOVA)
     set(BUILD_SHARED_LIBS ${BUILD_SHARED_LIBS_ORIGINAL_NOVA} CACHE BOOL "Reset BUILD_SHARED_LIBS value changed by nova to ${BUILD_SHARED_LIBS_ORIGINAL_NOVA}" FORCE)
+endif()
+
+if(MSVC)
+    # TODO: Non-hacky solution when someone who knows what they're doing can do things
+    string(REPLACE "/" "\\" WINDOWS_SAFE_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR})
+    add_custom_command(TARGET nova-test-unit
+        POST_BUILD
+        COMMAND IF EXIST "${WINDOWS_SAFE_BINARY_DIR}\\..\\bin\\Debug\\gtestd.dll"       copy /Y "${WINDOWS_SAFE_BINARY_DIR}\\..\\bin\\Debug\\gtestd.dll" "${WINDOWS_SAFE_BINARY_DIR}\\..\\Debug\\gtestd.dll"
+        COMMAND IF EXIST "${WINDOWS_SAFE_BINARY_DIR}\\..\\bin\\Debug\\gtest_maind.dll"  copy /Y "${WINDOWS_SAFE_BINARY_DIR}\\..\\bin\\Debug\\gtest_maind.dll" "${WINDOWS_SAFE_BINARY_DIR}\\..\\Debug\\gtest_maind.dll"
+        COMMAND IF EXIST "${WINDOWS_SAFE_BINARY_DIR}\\..\\bin\\Release\\gtest.dll"      copy /Y "${WINDOWS_SAFE_BINARY_DIR}\\..\\bin\\Release\\gtest.dll" "${WINDOWS_SAFE_BINARY_DIR}\\..\\Release\\gtest.dll"
+        COMMAND IF EXIST "${WINDOWS_SAFE_BINARY_DIR}\\..\\bin\\Release\\gtest_main.dll" copy /Y "${WINDOWS_SAFE_BINARY_DIR}\\..\\bin\\Release\\gtest_main.dll" "${WINDOWS_SAFE_BINARY_DIR}\\..\\Release\\gtest_main.dll"
+        )
 endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -44,3 +44,15 @@ remove_permissive(nova-test-unit)
 if(DEFINED BUILD_SHARED_LIBS_ORIGINAL_NOVA)
     set(BUILD_SHARED_LIBS ${BUILD_SHARED_LIBS_ORIGINAL_NOVA} CACHE BOOL "Reset BUILD_SHARED_LIBS value changed by nova to ${BUILD_SHARED_LIBS_ORIGINAL_NOVA}" FORCE)
 endif()
+
+if(MSVC)
+    # TODO: Non-hacky solution when someone who knows what they're doing can do things
+    string(REPLACE "/" "\\" WINDOWS_SAFE_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR})
+    add_custom_command(TARGET nova-test-unit
+        POST_BUILD
+        COMMAND IF EXIST "${WINDOWS_SAFE_BINARY_DIR}\\..\\bin\\Debug\\gtestd.dll"       copy /Y "${WINDOWS_SAFE_BINARY_DIR}\\..\\bin\\Debug\\gtestd.dll" "${WINDOWS_SAFE_BINARY_DIR}\\..\\Debug\\gtestd.dll"
+        COMMAND IF EXIST "${WINDOWS_SAFE_BINARY_DIR}\\..\\bin\\Debug\\gtest_maind.dll"  copy /Y "${WINDOWS_SAFE_BINARY_DIR}\\..\\bin\\Debug\\gtest_maind.dll" "${WINDOWS_SAFE_BINARY_DIR}\\..\\Debug\\gtest_maind.dll"
+        COMMAND IF EXIST "${WINDOWS_SAFE_BINARY_DIR}\\..\\bin\\Release\\gtest.dll"      copy /Y "${WINDOWS_SAFE_BINARY_DIR}\\..\\bin\\Release\\gtest.dll" "${WINDOWS_SAFE_BINARY_DIR}\\..\\Release\\gtest.dll"
+        COMMAND IF EXIST "${WINDOWS_SAFE_BINARY_DIR}\\..\\bin\\Release\\gtest_main.dll" copy /Y "${WINDOWS_SAFE_BINARY_DIR}\\..\\bin\\Release\\gtest_main.dll" "${WINDOWS_SAFE_BINARY_DIR}\\..\\Release\\gtest_main.dll"
+        )
+endif()

--- a/tests/src/end_to_end_runner.cpp
+++ b/tests/src/end_to_end_runner.cpp
@@ -7,7 +7,6 @@
 #undef TEST
 
 #include <iostream>
-#include <gtest/gtest.h>
 
 #ifdef __linux__
 void sigsegv_handler(int signal);

--- a/tests/src/end_to_end_runner.cpp
+++ b/tests/src/end_to_end_runner.cpp
@@ -9,6 +9,7 @@
 #include <iostream>
 
 #ifdef __linux__
+#include <signal.h>
 void sigsegv_handler(int signal);
 void sigabrt_handler(int signal);
 #include "../../src/util/linux_utils.hpp"


### PR DESCRIPTION
- Only require CMake 3.10, not 3.13 
- Make AppVeyor yell at us when builds fail