### PR TITLE
Procedural mesh class

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -344,9 +344,8 @@ set_target_properties(nova-renderer PROPERTIES POSITION_INDEPENDENT_CODE TRUE)
 target_compile_definitions(nova-renderer PUBLIC DUMP_NOVA_CALLS)
 target_compile_definitions(nova-renderer PUBLIC MTR_ENABLED)
 target_compile_definitions(nova-renderer PUBLIC FMT_STRING_ALIAS=1)
-if(CMAKE_BUILD_TYPE MATCHES DEBUG)
-    target_compile_definitions(nova-renderer PUBLIC NOVA_DEBUG)
-endif()
+target_compile_definitions(nova-renderer PUBLIC $<$<CONFIG:Debug>:NOVA_DEBUG>)
+
 target_include_directories(nova-renderer PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
         $ENV{VULKAN_SDK}/Include

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,6 +135,7 @@ set(NOVA_SOURCE
 		
         src/render_objects/procedural_mesh.cpp
         src/render_objects/uniform_structs.hpp
+        src/render_objects/renderables.cpp
 
         src/util/logger.cpp
         src/util/logger.hpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,7 @@ option(NOVA_ENABLE_VULKAN_RHI "Compile the Vulkan RHI backend" ON)
 option(NOVA_ENABLE_D3D12_RHI "Compile the D3D12 RHI backend" ON)
 option(NOVA_ENABLE_OPENGL_RHI "Compile the OpenGL 3 backend" ON)
 
-option(NOVA_FORCE_DEBUGGING "Force compiling all the debugging and validation code" ON)
+option(NOVA_FORCE_DEBUGGING "Force compiling all the debugging and validation code" OFF)
 
 if(NOVA_ENABLE_D3D12_API AND NOT WIN32)
     message(WARNING "Nova can only compile its D3D12 RHI backend on Windows 10. You're now on Windows 10, so I'm disabling the D3D12 RHI backend")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,6 +97,7 @@ set(NOVA_SOURCE
         include/nova_renderer/util/platform.hpp
         include/nova_renderer/util/result.hpp
         include/nova_renderer/util/utils.hpp
+        include/nova_renderer/util/container_accessor.hpp
 
         include/nova_renderer/command_list.hpp
         include/nova_renderer/device_memory_resource.hpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,6 +115,7 @@ set(NOVA_SOURCE
         include/nova_renderer/bytes.hpp
         include/nova_renderer/polyalloc.hpp
         include/nova_renderer/constants.hpp
+        include/nova_renderer/frontend/procedural_mesh.hpp
 
         src/nova_renderer.cpp
         src/render_engine/render_engine.cpp
@@ -130,7 +131,8 @@ set(NOVA_SOURCE
         src/loading/json_utils.hpp
 
         src/settings/nova_settings.cpp
-
+		
+        src/render_objects/procedural_mesh.cpp
         src/render_objects/uniform_structs.hpp
 
         src/util/logger.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -344,6 +344,9 @@ set_target_properties(nova-renderer PROPERTIES POSITION_INDEPENDENT_CODE TRUE)
 target_compile_definitions(nova-renderer PUBLIC DUMP_NOVA_CALLS)
 target_compile_definitions(nova-renderer PUBLIC MTR_ENABLED)
 target_compile_definitions(nova-renderer PUBLIC FMT_STRING_ALIAS=1)
+if(CMAKE_BUILD_TYPE MATCHES DEBUG)
+    target_compile_definitions(nova-renderer PUBLIC NOVA_DEBUG)
+endif()
 target_include_directories(nova-renderer PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
         $ENV{VULKAN_SDK}/Include
@@ -367,26 +370,6 @@ if(NOVA_ENABLE_OPENGL_RHI)
 endif()
 
 include(GNUInstallDirs)
-
-# TODO: Never care about CMake packages ever again
-# install(
-#     TARGETS nova-renderer
-#     EXPORT nova-renderer-config
-#     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}/
-#     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}/
-#     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}/
-# )
-# 
-# install(
-#     EXPORT nova-renderer-config DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/nova-renderer
-#     NAMESPACE nova-renderer::
-# )
-# 
-# install(
-#     DIRECTORY ${CMAKE_SOURCE_DIR}/src/
-#     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/nova-renderer
-#     FILES_MATCHING PATTERN "*.hpp*"
-# )
 
 ##################################
 # Add extra warnings if possible #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,8 @@ option(NOVA_ENABLE_VULKAN_RHI "Compile the Vulkan RHI backend" ON)
 option(NOVA_ENABLE_D3D12_RHI "Compile the D3D12 RHI backend" ON)
 option(NOVA_ENABLE_OPENGL_RHI "Compile the OpenGL 3 backend" ON)
 
+option(NOVA_FORCE_DEBUGGING "Force compiling all the debugging and validation code" ON)
+
 if(NOVA_ENABLE_D3D12_API AND NOT WIN32)
     message(WARNING "Nova can only compile its D3D12 RHI backend on Windows 10. You're now on Windows 10, so I'm disabling the D3D12 RHI backend")
     set(NOVA_ENABLE_D3D12_RHI_BACKEND OFF)
@@ -344,7 +346,12 @@ set_target_properties(nova-renderer PROPERTIES POSITION_INDEPENDENT_CODE TRUE)
 target_compile_definitions(nova-renderer PUBLIC DUMP_NOVA_CALLS)
 target_compile_definitions(nova-renderer PUBLIC MTR_ENABLED)
 target_compile_definitions(nova-renderer PUBLIC FMT_STRING_ALIAS=1)
-target_compile_definitions(nova-renderer PUBLIC $<$<CONFIG:Debug>:NOVA_DEBUG>)
+
+if(NOVA_FORCE_DEBUGGING) 
+    target_compile_definitions(nova-renderer PUBLIC NOVA_DEBUG)
+else()
+    target_compile_definitions(nova-renderer PUBLIC $<$<CONFIG:Debug>:NOVA_DEBUG>)
+endif()
 
 target_include_directories(nova-renderer PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>

--- a/include/nova_renderer/constants.hpp
+++ b/include/nova_renderer/constants.hpp
@@ -5,8 +5,8 @@
 #include <string>
 
 namespace nova::renderer {
-    constexpr std::string_view MODEL_MATRIX_BUFFER_NAME = "NovaModelMatrixUBO";
-    constexpr std::string_view PER_FRAME_DATA_NAME = "NovaPerFrameUBO";
+    const std::string MODEL_MATRIX_BUFFER_NAME = "NovaModelMatrixUBO";
+    const std::string PER_FRAME_DATA_NAME = "NovaPerFrameUBO";
 
     constexpr uint32_t AMD_PCI_VENDOR_ID = 0x1022;
     constexpr uint32_t INTEL_PCI_VENDOR_ID = 8086;

--- a/include/nova_renderer/constants.hpp
+++ b/include/nova_renderer/constants.hpp
@@ -11,4 +11,6 @@ namespace nova::renderer {
     const uint32_t AMD_PCI_VENDOR_ID = 0x1022;
     const uint32_t INTEL_PCI_VENDOR_ID = 8086;
     const uint32_t NVIDIA_PCI_VENDOR_ID = 0x10DE;
+
+    const uint8_t NUM_IN_FLIGHT_FRAMES = 3;
 }

--- a/include/nova_renderer/constants.hpp
+++ b/include/nova_renderer/constants.hpp
@@ -5,12 +5,12 @@
 #include <string>
 
 namespace nova::renderer {
-    const std::string MODEL_MATRIX_BUFFER_NAME = "NovaModelMatrixUBO";
-    const std::string PER_FRAME_DATA_NAME = "NovaPerFrameUBO";
+    constexpr std::string_view MODEL_MATRIX_BUFFER_NAME = "NovaModelMatrixUBO";
+    constexpr std::string_view PER_FRAME_DATA_NAME = "NovaPerFrameUBO";
 
-    const uint32_t AMD_PCI_VENDOR_ID = 0x1022;
-    const uint32_t INTEL_PCI_VENDOR_ID = 8086;
-    const uint32_t NVIDIA_PCI_VENDOR_ID = 0x10DE;
+    constexpr uint32_t AMD_PCI_VENDOR_ID = 0x1022;
+    constexpr uint32_t INTEL_PCI_VENDOR_ID = 8086;
+    constexpr uint32_t NVIDIA_PCI_VENDOR_ID = 0x10DE;
 
-    const uint8_t NUM_IN_FLIGHT_FRAMES = 3;
+    constexpr uint8_t NUM_IN_FLIGHT_FRAMES = 3;
 }

--- a/include/nova_renderer/frontend/procedural_mesh.hpp
+++ b/include/nova_renderer/frontend/procedural_mesh.hpp
@@ -1,15 +1,16 @@
 #pragma once
 
-#include <cstdint>
 #include <array>
+#include <cstdint>
 
 #include "nova_renderer/constants.hpp"
 
 namespace nova::renderer {
     namespace rhi {
+        class CommandList;
         class RenderEngine;
         class Buffer;
-    }
+    } // namespace rhi
 
     /*!
      * \brief ProceduralMesh is a mesh which the user will modify every frame
@@ -19,15 +20,57 @@ namespace nova::renderer {
      */
     class ProceduralMesh {
     public:
-        ProceduralMesh(uint64_t vertex_buffer_size, uint64_t index_buffer_size, rhi::RenderEngine& render_engine);
+        /*!
+         * \brief Creates a new procedural mesh which has the specified amount of space
+         *
+         * \param vertex_buffer_size The number of bytes the vertex buffer needs
+         * \param index_buffer_size The number of bytes that the index buffer needs
+         * \param device The device to create the buffers on
+         */
+        ProceduralMesh(uint64_t vertex_buffer_size, uint64_t index_buffer_size, rhi::RenderEngine& device);
+
+        /*!
+         * \brief Sets the data to upload to the vertex buffer
+         *
+         * \param data A pointer to the start of the data
+         * \param size The number of bytes to upload
+         */
+        void set_vertex_data(const void* data, uint64_t size);
+
+        /*!
+         * \brief Sets the data to upload to the index buffer
+         *
+         * \param data A pointer to the start of the data
+         * \param size The number of bytes to upload
+         */
+        void set_index_data(const void* data, uint64_t size);
+
+        /*!
+         * \brief Records commands to copy the staging buffers to the device buffers for the specified frame
+         *
+         * Intent is that you call this method at the beginning or the frame that will use the buffers you're uploading to. It's a method on
+         * this class mostly because writing accessors is hard
+         *
+         * \param cmds The command list to record commands into
+         * \param frame_idx The index of the frame to write the data to
+         */
+        void record_commands_to_upload_data(rhi::CommandList* cmds, uint8_t frame_idx);
 
     private:
         rhi::RenderEngine& render_engine;
 
         std::array<rhi::Buffer*, NUM_IN_FLIGHT_FRAMES> vertex_buffers;
-		std::array<rhi::Buffer*, NUM_IN_FLIGHT_FRAMES> index_buffers;
+        std::array<rhi::Buffer*, NUM_IN_FLIGHT_FRAMES> index_buffers;
 
         rhi::Buffer* cached_vertex_buffer;
         rhi::Buffer* cached_index_buffer;
+
+        uint64_t num_vertex_bytes_to_upload = 0;
+        uint64_t num_index_bytes_to_upload = 0;
+
+#ifndef NDEBUG
+        uint64_t vertex_buffer_size;
+        uint64_t index_buffer_size;
+#endif
     };
 } // namespace nova::renderer

--- a/include/nova_renderer/frontend/procedural_mesh.hpp
+++ b/include/nova_renderer/frontend/procedural_mesh.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+namespace nova::renderer {
+    /*!
+     * \brief ProceduralMesh is a mesh which the user will modify every frame
+     *
+     * ProceduralMesh should _not_ be used if you're not going
+     */
+    class ProceduralMesh {
+        
+    };
+}

--- a/include/nova_renderer/frontend/procedural_mesh.hpp
+++ b/include/nova_renderer/frontend/procedural_mesh.hpp
@@ -76,7 +76,7 @@ namespace nova::renderer {
         uint64_t num_vertex_bytes_to_upload = 0;
         uint64_t num_index_bytes_to_upload = 0;
 
-#ifndef NDEBUG
+#ifdef NOVA_DEBUG
         uint64_t vertex_buffer_size;
         uint64_t index_buffer_size;
 #endif

--- a/include/nova_renderer/frontend/procedural_mesh.hpp
+++ b/include/nova_renderer/frontend/procedural_mesh.hpp
@@ -28,7 +28,7 @@ namespace nova::renderer {
          * \param index_buffer_size The number of bytes that the index buffer needs
          * \param device The device to create the buffers on
          */
-        ProceduralMesh(uint64_t vertex_buffer_size, uint64_t index_buffer_size, rhi::RenderEngine& device);
+        ProceduralMesh(uint64_t vertex_buffer_size, uint64_t index_buffer_size, rhi::RenderEngine* device);
 
         /*!
          * \brief Sets the data to upload to the vertex buffer
@@ -58,7 +58,7 @@ namespace nova::renderer {
         void record_commands_to_upload_data(rhi::CommandList* cmds, uint8_t frame_idx);
 
     private:
-        rhi::RenderEngine& render_engine;
+        rhi::RenderEngine* device;
 
         std::array<rhi::Buffer*, NUM_IN_FLIGHT_FRAMES> vertex_buffers;
         std::array<rhi::Buffer*, NUM_IN_FLIGHT_FRAMES> index_buffers;

--- a/include/nova_renderer/frontend/procedural_mesh.hpp
+++ b/include/nova_renderer/frontend/procedural_mesh.hpp
@@ -1,12 +1,33 @@
 #pragma once
 
+#include <cstdint>
+#include <array>
+
+#include "nova_renderer/constants.hpp"
+
 namespace nova::renderer {
+    namespace rhi {
+        class RenderEngine;
+        class Buffer;
+    }
+
     /*!
      * \brief ProceduralMesh is a mesh which the user will modify every frame
      *
-     * ProceduralMesh should _not_ be used if you're not going
+     * ProceduralMesh should _not_ be used if you're not going to update the mesh frequently. It stores four copies of the mesh data - once
+     * in host memory, and three times in device memory (one for each in-flight frame)
      */
     class ProceduralMesh {
-        
+    public:
+        ProceduralMesh(uint64_t vertex_buffer_size, uint64_t index_buffer_size, rhi::RenderEngine& render_engine);
+
+    private:
+        rhi::RenderEngine& render_engine;
+
+        std::array<rhi::Buffer*, NUM_IN_FLIGHT_FRAMES> vertex_buffers;
+		std::array<rhi::Buffer*, NUM_IN_FLIGHT_FRAMES> index_buffers;
+
+        rhi::Buffer* cached_vertex_buffer;
+        rhi::Buffer* cached_index_buffer;
     };
-}
+} // namespace nova::renderer

--- a/include/nova_renderer/frontend/procedural_mesh.hpp
+++ b/include/nova_renderer/frontend/procedural_mesh.hpp
@@ -7,9 +7,10 @@
 
 namespace nova::renderer {
     namespace rhi {
+        struct Buffer;
+
         class CommandList;
         class RenderEngine;
-        class Buffer;
     } // namespace rhi
 
     /*!

--- a/include/nova_renderer/frontend/procedural_mesh.hpp
+++ b/include/nova_renderer/frontend/procedural_mesh.hpp
@@ -21,6 +21,8 @@ namespace nova::renderer {
      */
     class ProceduralMesh {
     public:
+        ProceduralMesh() = default;
+
         /*!
          * \brief Creates a new procedural mesh which has the specified amount of space
          *
@@ -56,6 +58,11 @@ namespace nova::renderer {
          * \param frame_idx The index of the frame to write the data to
          */
         void record_commands_to_upload_data(rhi::CommandList* cmds, uint8_t frame_idx);
+
+        /*!
+         * \brief Returns the vertex and index buffer for the provided frame
+         */
+        [[nodiscard]] std::tuple<rhi::Buffer*, rhi::Buffer*> get_buffers_for_frame(uint8_t frame_idx) const;
 
     private:
         rhi::RenderEngine* device;

--- a/include/nova_renderer/nova_renderer.hpp
+++ b/include/nova_renderer/nova_renderer.hpp
@@ -14,6 +14,7 @@
 #include "constants.hpp"
 #include "renderables.hpp"
 #include "util/container_accessor.hpp"
+#include "frontend/procedural_mesh.hpp"
 
 namespace spirv_cross {
     class CompilerGLSL;
@@ -21,8 +22,6 @@ namespace spirv_cross {
 } // namespace spirv_cross
 
 namespace nova::renderer {
-    class ProceduralMesh;
-
     namespace rhi {
         class Swapchain;
     }

--- a/include/nova_renderer/nova_renderer.hpp
+++ b/include/nova_renderer/nova_renderer.hpp
@@ -2,8 +2,8 @@
 
 #include <array>
 #include <memory>
-#include <string>
 #include <mutex>
+#include <string>
 
 #include "nova_renderer/device_memory_resource.hpp"
 #include "nova_renderer/nova_settings.hpp"
@@ -11,8 +11,9 @@
 #include "nova_renderer/render_engine.hpp"
 #include "nova_renderer/renderdoc_app.h"
 
-#include "renderables.hpp"
 #include "constants.hpp"
+#include "renderables.hpp"
+#include "util/container_accessor.hpp"
 
 namespace spirv_cross {
     class CompilerGLSL;
@@ -20,6 +21,8 @@ namespace spirv_cross {
 } // namespace spirv_cross
 
 namespace nova::renderer {
+    class ProceduralMesh;
+
     namespace rhi {
         class Swapchain;
     }
@@ -175,6 +178,11 @@ namespace nova::renderer {
         [[nodiscard]] MeshId create_mesh(const MeshData& mesh_data);
 
         /*!
+         * \brief Creates a procedural mesh, returning both its mesh id and 
+         */
+        [[nodiscard]] MapAccessor<MeshId, ProceduralMesh> create_procedural_mesh(uint64_t vertex_size, uint64_t index_size);
+
+        /*!
          * \brief Destroys the mesh with the provided ID, freeing up whatever VRAM it was using
          *
          * In debug builds, this method checks that no renderables are using the mesh
@@ -184,7 +192,8 @@ namespace nova::renderer {
         void destroy_mesh(MeshId mesh_to_destroy);
 #pragma endregion
 
-        RenderableId add_renderable_for_material(const FullMaterialPassName& material_name, const StaticMeshRenderableData& renderable);
+        [[nodiscard]] RenderableId add_renderable_for_material(const FullMaterialPassName& material_name,
+                                                               const StaticMeshRenderableData& renderable);
 
         [[nodiscard]] rhi::RenderEngine* get_engine() const;
 
@@ -319,6 +328,7 @@ namespace nova::renderer {
         MeshId next_mesh_id = 0;
 
         std::unordered_map<MeshId, Mesh> meshes;
+        std::unordered_map<MeshId, ProceduralMesh> proc_meshes;
 #pragma endregion
 
 #pragma region Rendering

--- a/include/nova_renderer/nova_renderer.hpp
+++ b/include/nova_renderer/nova_renderer.hpp
@@ -366,10 +366,10 @@ namespace nova::renderer {
         void record_renderpass(Renderpass& renderpass, rhi::CommandList* cmds);
 
         void record_pipeline(Pipeline& pipeline, rhi::CommandList* cmds);
-
         void record_material_pass(MaterialPass& pass, rhi::CommandList* cmds);
 
-        void record_rendering_static_mesh_batch(MeshBatch<StaticMeshRenderCommand>& batch, rhi::CommandList* cmds);
+        void record_rendering_static_mesh_batch(const MeshBatch<StaticMeshRenderCommand>& batch, rhi::CommandList* cmds);
+        void record_rendering_static_mesh_batch(const ProceduralMeshBatch<StaticMeshRenderCommand>& batch, rhi::CommandList* cmds);
 #pragma endregion
     };
 } // namespace nova::renderer

--- a/include/nova_renderer/nova_renderer.hpp
+++ b/include/nova_renderer/nova_renderer.hpp
@@ -28,7 +28,7 @@ namespace nova::renderer {
     }
 
 #pragma region Runtime optimized data
-    template <typename RenderableType>
+    template <typename RenderCommandType>
     struct MeshBatch {
         rhi::Buffer* vertex_buffer = nullptr;
         rhi::Buffer* index_buffer = nullptr;
@@ -43,13 +43,34 @@ namespace nova::renderer {
          */
         rhi::Buffer* per_renderable_data = nullptr;
 
-        std::vector<RenderableType> renderables;
+        std::vector<RenderCommandType> commands;
+    };
+
+    template<typename RenderCommandType>
+    struct ProceduralMeshBatch {
+        MapAccessor<MeshId, ProceduralMesh> mesh;
+        
+        /*!
+         * \brief A buffer to hold all the per-draw data
+         *
+         * For example, a non-animated mesh just needs a mat4 for its model matrix
+         *
+         * This buffer gets re-written to every frame, since the number of renderables in this mesh batch might have changed. If there's
+         * more renderables than the buffer can hold, it gets reallocated from the RHI
+         */
+        rhi::Buffer* per_renderable_data = nullptr;
+
+        std::vector<RenderCommandType> commands;
+
+        ProceduralMeshBatch(std::unordered_map<MeshId, ProceduralMesh>& meshes, MeshId key) : mesh(meshes, key) {}
     };
 
     struct MaterialPass {
         // Descriptors for the material pass
 
         std::vector<MeshBatch<StaticMeshRenderCommand>> static_mesh_draws;
+        std::vector<ProceduralMeshBatch<StaticMeshRenderCommand>> static_procedural_mesh_draws;
+
         std::vector<rhi::DescriptorSet*> descriptor_sets;
         const rhi::PipelineInterface* pipeline_interface = nullptr;
     };

--- a/include/nova_renderer/nova_renderer.hpp
+++ b/include/nova_renderer/nova_renderer.hpp
@@ -11,8 +11,8 @@
 #include "nova_renderer/render_engine.hpp"
 #include "nova_renderer/renderdoc_app.h"
 
-#include "../../src/render_engine/configuration.hpp"
 #include "renderables.hpp"
+#include "constants.hpp"
 
 namespace spirv_cross {
     class CompilerGLSL;

--- a/include/nova_renderer/renderables.hpp
+++ b/include/nova_renderer/renderables.hpp
@@ -55,7 +55,7 @@ namespace nova::renderer {
         std::vector<std::string> passes;
     };
 
-    struct RenderableBase {
+    struct RenderCommand {
         RenderableId id = 0;
 
         bool is_visible = true;
@@ -63,7 +63,7 @@ namespace nova::renderer {
         glm::mat4 model_matrix = glm::mat4(1);
     };
 
-    struct StaticMeshRenderCommand : RenderableBase {};
+    struct StaticMeshRenderCommand : RenderCommand {};
 
     StaticMeshRenderCommand make_render_command(const StaticMeshRenderableData& data, RenderableId id);
 } // namespace nova::renderer

--- a/include/nova_renderer/renderables.hpp
+++ b/include/nova_renderer/renderables.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <atomic>
+#include <string>
+#include <vector>
 
 #include <glm/glm.hpp>
 
@@ -62,4 +64,6 @@ namespace nova::renderer {
     };
 
     struct StaticMeshRenderCommand : RenderableBase {};
+
+    StaticMeshRenderCommand make_render_command(const StaticMeshRenderableData& data, RenderableId id);
 } // namespace nova::renderer

--- a/include/nova_renderer/swapchain.hpp
+++ b/include/nova_renderer/swapchain.hpp
@@ -20,7 +20,7 @@ namespace nova::renderer::rhi {
          * 
          * \return The index of the swapchain image we just acquired
          */
-        virtual uint32_t acquire_next_swapchain_image() = 0;
+        virtual uint8_t acquire_next_swapchain_image() = 0;
         
         /*!
          * \brief Presents the specified swapchain image

--- a/include/nova_renderer/util/container_accessor.hpp
+++ b/include/nova_renderer/util/container_accessor.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <vector>
+
+namespace nova::renderer {
+    /*!
+     * \brief Allows one to access a thing at a location in a vector, even after the vector has been reallocated
+     *
+     * How this isn't in the standard library, idk
+     */
+    template<typename T>
+    class VectorAccessor {
+    public:
+        VectorAccessor(const std::vector<T>& vec, const std::size_t idx) : vec(vec), idx(idx) {}
+
+        T* operator->() {
+            return &vec[idx];
+        }
+
+    private:
+        std::vector<T>& vec;
+        std::size_t idx;
+    };
+}

--- a/include/nova_renderer/util/container_accessor.hpp
+++ b/include/nova_renderer/util/container_accessor.hpp
@@ -13,7 +13,7 @@ namespace nova::renderer {
     public:
         MapAccessor(std::unordered_map<KeyType, ValueType>& map, const KeyType key) : map(map), key(key) {}
 
-        ValueType* operator->() {
+        ValueType* operator->() const {
             return &map[key];
         }
 

--- a/include/nova_renderer/util/container_accessor.hpp
+++ b/include/nova_renderer/util/container_accessor.hpp
@@ -8,17 +8,21 @@ namespace nova::renderer {
      *
      * How this isn't in the standard library, idk
      */
-    template<typename T>
-    class VectorAccessor {
+    template<typename KeyType, typename ValueType>
+    class MapAccessor {
     public:
-        VectorAccessor(const std::vector<T>& vec, const std::size_t idx) : vec(vec), idx(idx) {}
+        MapAccessor(std::unordered_map<KeyType, ValueType>& map, const KeyType key) : map(map), key(key) {}
 
-        T* operator->() {
-            return &vec[idx];
+        ValueType* operator->() {
+            return &map[key];
+        }
+
+        KeyType get_key() const {
+            return key;
         }
 
     private:
-        std::vector<T>& vec;
-        std::size_t idx;
+        std::unordered_map<KeyType, ValueType>& map;
+        KeyType key;
     };
 }

--- a/src/nova_renderer.cpp
+++ b/src/nova_renderer.cpp
@@ -828,13 +828,7 @@ namespace nova::renderer {
         if (start_index != cur_model_matrix_index) {
         const auto& [vertex_buffer, index_buffer] = batch.mesh->get_buffers_for_frame(cur_frame_idx);
             // TODO: There's probably a better way to do this
-            const std::vector<rhi::Buffer*> vertex_buffers = { vertex_buffer,
-                                                              vertex_buffer,
-                                                              vertex_buffer,
-                                                              vertex_buffer,
-                                                              vertex_buffer,
-                                                              vertex_buffer,
-                                                              vertex_buffer };
+            const std::vector<rhi::Buffer*> vertex_buffers = { 7, vertex_buffer };
             cmds->bind_vertex_buffers(vertex_buffers);
             cmds->bind_index_buffer(index_buffer);
 

--- a/src/nova_renderer.cpp
+++ b/src/nova_renderer.cpp
@@ -13,6 +13,7 @@
 
 #include "nova_renderer/command_list.hpp"
 #include "nova_renderer/constants.hpp"
+#include "nova_renderer/frontend/procedural_mesh.hpp"
 #include "nova_renderer/swapchain.hpp"
 #include "nova_renderer/util/platform.hpp"
 
@@ -248,6 +249,15 @@ namespace nova::renderer {
         meshes.emplace(new_mesh_id, mesh);
 
         return new_mesh_id;
+    }
+
+    MapAccessor<MeshId, ProceduralMesh> NovaRenderer::create_procedural_mesh(const uint64_t vertex_size, const uint64_t index_size) {
+        MeshId our_id = next_mesh_id;
+        next_mesh_id++;
+
+        proc_meshes.emplace(our_id, vertex_size, index_size, *rhi.get());
+
+        return MapAccessor<MeshId, ProceduralMesh>(proc_meshes, our_id);
     }
 
     void NovaRenderer::load_shaderpack(const std::string& shaderpack_name) {

--- a/src/nova_renderer.cpp
+++ b/src/nova_renderer.cpp
@@ -147,6 +147,8 @@ namespace nova::renderer {
 
         rhi::CommandList* cmds = rhi->get_command_list(0, rhi::QueueType::Graphics);
 
+        // TODO: Upload procedural mesh staging buffers to the procedural meshes
+
         for(Renderpass& renderpass : renderpasses) {
             record_renderpass(renderpass, cmds);
         }
@@ -255,7 +257,7 @@ namespace nova::renderer {
         MeshId our_id = next_mesh_id;
         next_mesh_id++;
 
-        proc_meshes.emplace(our_id, ProceduralMesh(vertex_size, index_size, *rhi.get()));
+        proc_meshes.emplace(our_id, ProceduralMesh(vertex_size, index_size, rhi.get()));
 
         return MapAccessor<MeshId, ProceduralMesh>(proc_meshes, our_id);
     }

--- a/src/render_engine/configuration.hpp
+++ b/src/render_engine/configuration.hpp
@@ -1,3 +1,0 @@
-#pragma once
-
-#define NUM_IN_FLIGHT_FRAMES    3

--- a/src/render_engine/dx12/dx12_swapchain.cpp
+++ b/src/render_engine/dx12/dx12_swapchain.cpp
@@ -24,7 +24,7 @@ namespace nova::renderer::rhi {
         create_per_frame_resources(device);
     }
 
-    uint32_t DX12Swapchain::acquire_next_swapchain_image() { return swapchain->GetCurrentBackBufferIndex(); }
+    uint8_t DX12Swapchain::acquire_next_swapchain_image() { return static_cast<uint8_t>(swapchain->GetCurrentBackBufferIndex()); }
 
     void DX12Swapchain::present(uint32_t /* image_idx */) { swapchain->Present(0, DXGI_PRESENT_RESTRICT_TO_OUTPUT); }
 

--- a/src/render_engine/dx12/dx12_swapchain.hpp
+++ b/src/render_engine/dx12/dx12_swapchain.hpp
@@ -25,7 +25,7 @@ namespace nova::renderer::rhi {
         ~DX12Swapchain() override = default;
 
 #pragma region Swapchain implementation
-        uint32_t acquire_next_swapchain_image() override;
+        uint8_t acquire_next_swapchain_image() override;
 
         void present(uint32_t image_idx) override;
 #pragma endregion

--- a/src/render_engine/dx12/dx12_utils.hpp
+++ b/src/render_engine/dx12/dx12_utils.hpp
@@ -26,7 +26,7 @@ namespace nova::renderer::rhi {
 
     [[nodiscard]] std::string to_string(HRESULT hr);
 
-#ifndef NDEBUG
+#ifdef NOVA_DEBUG
 #define CHECK_ERROR(expr, msg)                                                                                                             \
     {                                                                                                                                      \
         HRESULT hr = expr;                                                                                                                 \

--- a/src/render_engine/gl3/gl3_swapchain.cpp
+++ b/src/render_engine/gl3/gl3_swapchain.cpp
@@ -10,8 +10,8 @@ namespace nova::renderer::rhi {
         }
     }
 
-    uint32_t Gl3Swapchain::acquire_next_swapchain_image() {
-        const uint32_t ret_val = cur_frame;
+    uint8_t Gl3Swapchain::acquire_next_swapchain_image() {
+        const uint8_t ret_val = cur_frame;
         cur_frame++;
         if(cur_frame >= num_images) {
             cur_frame = 0;

--- a/src/render_engine/gl3/gl3_swapchain.hpp
+++ b/src/render_engine/gl3/gl3_swapchain.hpp
@@ -8,11 +8,11 @@ namespace nova::renderer::rhi {
 
         ~Gl3Swapchain() override = default;
 
-        uint32_t acquire_next_swapchain_image() override;
+        uint8_t acquire_next_swapchain_image() override;
 
         void present(uint32_t image_idxs) override;
 
     private:
-        uint32_t cur_frame = 0;
+        uint8_t cur_frame = 0;
     };
 }

--- a/src/render_engine/vulkan/vulkan_render_engine.cpp
+++ b/src/render_engine/vulkan/vulkan_render_engine.cpp
@@ -26,7 +26,6 @@
 #include "nova_renderer/constants.hpp"
 
 #include "../../util/memory_utils.hpp"
-#include "../configuration.hpp"
 
 namespace nova::renderer::rhi {
     VulkanRenderEngine::VulkanRenderEngine(NovaSettingsAccessManager& settings) // NOLINT(cppcoreguidelines-pro-type-member-init)

--- a/src/render_engine/vulkan/vulkan_swapchain.cpp
+++ b/src/render_engine/vulkan/vulkan_swapchain.cpp
@@ -48,7 +48,7 @@ namespace nova::renderer::rhi {
         transition_swapchain_images_into_color_attachment_layout(vk_images);
     }
 
-    uint32_t VulkanSwapchain::acquire_next_swapchain_image() {
+    uint8_t VulkanSwapchain::acquire_next_swapchain_image() {
         auto* fence = render_engine.create_fence();
         auto* vk_fence = static_cast<VulkanFence*>(fence);
 
@@ -71,7 +71,7 @@ namespace nova::renderer::rhi {
         // Block until we have the swapchain image in order to mimic D3D12. TODO: Reevaluate this decision
         render_engine.wait_for_fences({vk_fence});
 
-        return acquired_image_idx;
+        return static_cast<uint8_t>(acquired_image_idx);
     }
 
     void VulkanSwapchain::present(const uint32_t image_idx) {

--- a/src/render_engine/vulkan/vulkan_swapchain.hpp
+++ b/src/render_engine/vulkan/vulkan_swapchain.hpp
@@ -35,7 +35,7 @@ namespace nova::renderer::rhi {
                         const std::vector<VkPresentModeKHR>& present_modes);
 
 #pragma region Swapchain implementation
-        uint32_t acquire_next_swapchain_image() override;
+        uint8_t acquire_next_swapchain_image() override;
 
         void present(uint32_t image_idx) override;
 #pragma endregion

--- a/src/render_engine/vulkan/vulkan_utils.hpp
+++ b/src/render_engine/vulkan/vulkan_utils.hpp
@@ -42,7 +42,7 @@ namespace nova::renderer::rhi {
 
 // Only validate errors in debug mode
 // Release mode needs to be fast A F
-#ifndef NDEBUG
+#ifdef NOVA_DEBUG
 // NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
 #define NOVA_CHECK_RESULT(expr)                                                                                                            \
     {                                                                                                                                      \

--- a/src/render_objects/procedural_mesh.cpp
+++ b/src/render_objects/procedural_mesh.cpp
@@ -1,0 +1,1 @@
+#include "nova_renderer/frontend/procedural_mesh.hpp"

--- a/src/render_objects/procedural_mesh.cpp
+++ b/src/render_objects/procedural_mesh.cpp
@@ -10,7 +10,7 @@
 namespace nova::renderer {
     using namespace rhi;
 
-    ProceduralMesh::ProceduralMesh(uint64_t vertex_buffer_size, uint64_t index_buffer_size, RenderEngine& device)
+    ProceduralMesh::ProceduralMesh(const uint64_t vertex_buffer_size, const uint64_t index_buffer_size, RenderEngine& device)
         : render_engine(device)
 #ifndef NDEBUG
           ,
@@ -69,13 +69,42 @@ namespace nova::renderer {
     }
 
     void ProceduralMesh::set_vertex_data(const void* data, const uint64_t size) {
-        render_engine.write_data_to_buffer(data, size, 0, cached_vertex_buffer);
-        num_vertex_bytes_to_upload = size;
+#ifndef NDEBUG
+        if(size > vertex_buffer_size) {
+            NOVA_LOG(ERROR) << "Cannot upload vertex data. There's only space for " << vertex_buffer_size << " bytes, you tried to upload "
+                            << size << ". Truncating vertex data to fit";
+
+            render_engine.write_data_to_buffer(data, vertex_buffer_size, 0, cached_vertex_buffer);
+            num_vertex_bytes_to_upload = vertex_buffer_size;
+
+        } else {
+#endif
+
+            render_engine.write_data_to_buffer(data, size, 0, cached_vertex_buffer);
+            num_vertex_bytes_to_upload = size;
+
+#ifndef NDEBUG
+        }
+#endif
     }
 
     void ProceduralMesh::set_index_data(const void* data, const uint64_t size) {
-        render_engine.write_data_to_buffer(data, size, 0, cached_index_buffer);
-        num_index_bytes_to_upload = size;
+#ifndef NDEBUG
+        if(size > index_buffer_size) {
+            NOVA_LOG(ERROR) << "Cannot upload index data. There's only space for " << index_buffer_size << " bytes, you tried to upload "
+                            << size << ". Truncating vertex data to fit";
+
+            render_engine.write_data_to_buffer(data, index_buffer_size, 0, cached_index_buffer);
+            num_index_bytes_to_upload = index_buffer_size;
+
+        } else {
+#endif
+            render_engine.write_data_to_buffer(data, size, 0, cached_index_buffer);
+            num_index_bytes_to_upload = size;
+
+#ifndef NDEBUG
+        }
+#endif
     }
 
     void ProceduralMesh::record_commands_to_upload_data(CommandList* cmds, const uint8_t frame_idx) {

--- a/src/render_objects/procedural_mesh.cpp
+++ b/src/render_objects/procedural_mesh.cpp
@@ -42,7 +42,7 @@ namespace nova::renderer {
                     index_buffer = device.create_buffer(index_create_info, memory_resource);
                 }
 
-                return ntl::Result<bool>(true);
+                return true;
             })
             .on_error([](const ntl::NovaError& error) {
                 NOVA_LOG(ERROR) << "Could not allocate device memory for procedural mesh. Error: " << error.to_string();
@@ -60,7 +60,7 @@ namespace nova::renderer {
                 cached_vertex_buffer = device.create_buffer({vertex_buffer_size, BufferUsage::StagingBuffer}, memory_resource);
                 cached_index_buffer = device.create_buffer({index_buffer_size, BufferUsage::StagingBuffer}, memory_resource);
 
-                return ntl::Result<bool>(true);
+                return true;
             })
             .on_error([](const ntl::NovaError& error) {
                 NOVA_LOG(ERROR) << "Could not allocate host memory for procedural mesh. Error: " << error.to_string();

--- a/src/render_objects/procedural_mesh.cpp
+++ b/src/render_objects/procedural_mesh.cpp
@@ -23,7 +23,7 @@ namespace nova::renderer {
         const auto host_memory_size = aligned_vertex_buffer_size + aligned_index_buffer_size;
         const auto device_memory_size = host_memory_size * 3;
 
-        // TODO: Don't allocate a separate device memory for each procedural mesh
+        // TODO: Don't allocate a separate DeviceMemory for each procedural mesh
         device->allocate_device_memory(device_memory_size.b_count(), MemoryUsage::LowFrequencyUpload, ObjectType::Buffer)
             .map([&](DeviceMemory* memory) {
                 // TODO: Find a good way to keep these around

--- a/src/render_objects/procedural_mesh.cpp
+++ b/src/render_objects/procedural_mesh.cpp
@@ -1,1 +1,20 @@
 #include "nova_renderer/frontend/procedural_mesh.hpp"
+
+#include "nova_renderer/render_engine.hpp"
+
+namespace nova::renderer {
+    using namespace rhi;
+
+    ProceduralMesh::ProceduralMesh(uint64_t vertex_buffer_size, uint64_t index_buffer_size, rhi::RenderEngine& render_engine)
+        : render_engine(render_engine) {
+        DeviceMemory* vertex_buffer_memory = render_engine.allocate_device_memory(vertex_buffer_size * 3,
+                                                                                  MemoryUsage::LowFrequencyUpload,
+                                                                                  ObjectType::Buffer);
+
+        BufferCreateInfo vertex_create_info = {vertex_buffer_size, BufferUsage::VertexBuffer};
+
+        for(uint32_t i = 0; i < vertex_buffers.size(); i++) {
+            vertex_buffers
+        }
+    }
+} // namespace nova::renderer

--- a/src/render_objects/procedural_mesh.cpp
+++ b/src/render_objects/procedural_mesh.cpp
@@ -196,4 +196,11 @@ namespace nova::renderer {
 
         cmds->resource_barriers(PipelineStageFlags::Transfer, PipelineStageFlags::TopOfPipe, barriers_after_upload);
     }
+
+    std::tuple<Buffer*, Buffer*> ProceduralMesh::get_buffers_for_frame(const uint8_t frame_idx) const {
+        auto* vertex_buffer = vertex_buffers.at(frame_idx);
+        auto* index_buffer = index_buffers.at(frame_idx);
+
+        return {vertex_buffer, index_buffer};
+    }
 } // namespace nova::renderer

--- a/src/render_objects/procedural_mesh.cpp
+++ b/src/render_objects/procedural_mesh.cpp
@@ -12,7 +12,7 @@ namespace nova::renderer {
 
     ProceduralMesh::ProceduralMesh(const uint64_t vertex_buffer_size, const uint64_t index_buffer_size, RenderEngine* device)
         : device(device)
-#ifndef NDEBUG
+#ifdef NOVA_DEBUG
           ,
           vertex_buffer_size(vertex_buffer_size),
           index_buffer_size(index_buffer_size)
@@ -69,7 +69,7 @@ namespace nova::renderer {
     }
 
     void ProceduralMesh::set_vertex_data(const void* data, const uint64_t size) {
-#ifndef NDEBUG
+#ifdef NOVA_DEBUG
         if(size > vertex_buffer_size) {
             NOVA_LOG(ERROR) << "Cannot upload vertex data. There's only space for " << vertex_buffer_size << " bytes, you tried to upload "
                             << size << ". Truncating vertex data to fit";
@@ -83,13 +83,13 @@ namespace nova::renderer {
             device->write_data_to_buffer(data, size, 0, cached_vertex_buffer);
             num_vertex_bytes_to_upload = size;
 
-#ifndef NDEBUG
+#ifdef NOVA_DEBUG
         }
 #endif
     }
 
     void ProceduralMesh::set_index_data(const void* data, const uint64_t size) {
-#ifndef NDEBUG
+#ifdef NOVA_DEBUG
         if(size > index_buffer_size) {
             NOVA_LOG(ERROR) << "Cannot upload index data. There's only space for " << index_buffer_size << " bytes, you tried to upload "
                             << size << ". Truncating vertex data to fit";
@@ -102,7 +102,7 @@ namespace nova::renderer {
             device->write_data_to_buffer(data, size, 0, cached_index_buffer);
             num_index_bytes_to_upload = size;
 
-#ifndef NDEBUG
+#ifdef NOVA_DEBUG
         }
 #endif
     }

--- a/src/render_objects/procedural_mesh.cpp
+++ b/src/render_objects/procedural_mesh.cpp
@@ -82,8 +82,8 @@ namespace nova::renderer {
         const bool should_upload_vertex_buffer = num_vertex_bytes_to_upload > 0;
         const bool should_upload_index_buffer = num_index_bytes_to_upload > 0;
 
-		auto* cur_vertex_buffer = vertex_buffers.at(frame_idx);
-		auto* cur_index_buffer = index_buffers.at(frame_idx);
+        auto* cur_vertex_buffer = vertex_buffers.at(frame_idx);
+        auto* cur_index_buffer = index_buffers.at(frame_idx);
 
         std::vector<ResourceBarrier> barriers_before_upload;
 
@@ -104,17 +104,17 @@ namespace nova::renderer {
 
         if(should_upload_index_buffer) {
             ResourceBarrier barrier_before_index_upload = {};
-			barrier_before_index_upload.resource_to_barrier = cur_index_buffer;
-			barrier_before_index_upload.access_before_barrier = AccessFlags::IndexRead;
-			barrier_before_index_upload.access_after_barrier = AccessFlags::MemoryWrite;
-			barrier_before_index_upload.old_state = ResourceState::IndexBuffer;
-			barrier_before_index_upload.new_state = ResourceState::CopyDestination;
-			barrier_before_index_upload.source_queue = QueueType::Graphics;
-			barrier_before_index_upload.destination_queue = QueueType::Transfer;
-			barrier_before_index_upload.buffer_memory_barrier.offset = 0;
-			barrier_before_index_upload.buffer_memory_barrier.size = num_vertex_bytes_to_upload;
+            barrier_before_index_upload.resource_to_barrier = cur_index_buffer;
+            barrier_before_index_upload.access_before_barrier = AccessFlags::IndexRead;
+            barrier_before_index_upload.access_after_barrier = AccessFlags::MemoryWrite;
+            barrier_before_index_upload.old_state = ResourceState::IndexBuffer;
+            barrier_before_index_upload.new_state = ResourceState::CopyDestination;
+            barrier_before_index_upload.source_queue = QueueType::Graphics;
+            barrier_before_index_upload.destination_queue = QueueType::Transfer;
+            barrier_before_index_upload.buffer_memory_barrier.offset = 0;
+            barrier_before_index_upload.buffer_memory_barrier.size = num_vertex_bytes_to_upload;
 
-			barriers_before_upload.push_back(barrier_before_index_upload);
+            barriers_before_upload.push_back(barrier_before_index_upload);
         }
 
         if(barriers_before_upload.empty()) {
@@ -128,7 +128,7 @@ namespace nova::renderer {
         }
 
         if(should_upload_index_buffer) {
-			cmds->copy_buffer(cur_index_buffer, 0, cached_index_buffer, 0, num_index_bytes_to_upload);
+            cmds->copy_buffer(cur_index_buffer, 0, cached_index_buffer, 0, num_index_bytes_to_upload);
         }
 
         std::vector<ResourceBarrier> barriers_after_upload;
@@ -147,23 +147,23 @@ namespace nova::renderer {
             barriers_after_upload.push_back(barrier_after_vertex_upload);
         }
 
-		if (should_upload_index_buffer) {
-			ResourceBarrier barrier_after_index_upload = {};
-			barrier_after_index_upload.resource_to_barrier = cur_index_buffer;
-			barrier_after_index_upload.access_before_barrier = AccessFlags::MemoryWrite;
-			barrier_after_index_upload.access_after_barrier = AccessFlags::IndexRead;
-			barrier_after_index_upload.old_state = ResourceState::CopyDestination;
-			barrier_after_index_upload.new_state = ResourceState::IndexBuffer;
-			barrier_after_index_upload.source_queue = QueueType::Graphics;
-			barrier_after_index_upload.destination_queue = QueueType::Graphics;
-			barrier_after_index_upload.buffer_memory_barrier.offset = 0;
-			barrier_after_index_upload.buffer_memory_barrier.size = num_index_bytes_to_upload;
-			barriers_after_upload.push_back(barrier_after_index_upload);
-		}
+        if(should_upload_index_buffer) {
+            ResourceBarrier barrier_after_index_upload = {};
+            barrier_after_index_upload.resource_to_barrier = cur_index_buffer;
+            barrier_after_index_upload.access_before_barrier = AccessFlags::MemoryWrite;
+            barrier_after_index_upload.access_after_barrier = AccessFlags::IndexRead;
+            barrier_after_index_upload.old_state = ResourceState::CopyDestination;
+            barrier_after_index_upload.new_state = ResourceState::IndexBuffer;
+            barrier_after_index_upload.source_queue = QueueType::Graphics;
+            barrier_after_index_upload.destination_queue = QueueType::Graphics;
+            barrier_after_index_upload.buffer_memory_barrier.offset = 0;
+            barrier_after_index_upload.buffer_memory_barrier.size = num_index_bytes_to_upload;
+            barriers_after_upload.push_back(barrier_after_index_upload);
+        }
 
-		if (barriers_after_upload.empty()) {
-			return;
-		}
+        if(barriers_after_upload.empty()) {
+            return;
+        }
 
         cmds->resource_barriers(PipelineStageFlags::Transfer, PipelineStageFlags::TopOfPipe, barriers_after_upload);
     }

--- a/src/render_objects/procedural_mesh.cpp
+++ b/src/render_objects/procedural_mesh.cpp
@@ -10,15 +10,21 @@
 namespace nova::renderer {
     using namespace rhi;
 
-    ProceduralMesh::ProceduralMesh(uint64_t vertex_buffer_size, uint64_t index_buffer_size, rhi::RenderEngine& render_engine)
-        : render_engine(render_engine) {
+    ProceduralMesh::ProceduralMesh(uint64_t vertex_buffer_size, uint64_t index_buffer_size, RenderEngine& device)
+        : render_engine(device)
+#ifndef NDEBUG
+          ,
+          vertex_buffer_size(vertex_buffer_size),
+          index_buffer_size(index_buffer_size)
+#endif
+    {
         const auto aligned_vertex_buffer_size = bvestl::polyalloc::align(vertex_buffer_size, 256);
         const auto aligned_index_buffer_size = bvestl::polyalloc::align(index_buffer_size, 256);
         const auto host_memory_size = aligned_vertex_buffer_size + aligned_index_buffer_size;
         const auto device_memory_size = host_memory_size * 3;
 
         // TODO: Don't allocate a separate device memory for each procedural mesh
-        render_engine.allocate_device_memory(device_memory_size.b_count(), MemoryUsage::LowFrequencyUpload, ObjectType::Buffer)
+        device.allocate_device_memory(device_memory_size.b_count(), MemoryUsage::LowFrequencyUpload, ObjectType::Buffer)
             .map([&](DeviceMemory* memory) {
                 // TODO: Find a good way to keep these around
                 const auto
@@ -28,21 +34,22 @@ namespace nova::renderer {
 
                 const auto vertex_create_info = BufferCreateInfo{vertex_buffer_size, BufferUsage::VertexBuffer};
                 for(auto& vertex_buffer : vertex_buffers) {
-                    vertex_buffer = render_engine.create_buffer(vertex_create_info, memory_resource);
+                    vertex_buffer = device.create_buffer(vertex_create_info, memory_resource);
                 }
 
                 const auto index_create_info = BufferCreateInfo{index_buffer_size, BufferUsage::IndexBuffer};
                 for(auto& index_buffer : index_buffers) {
-                    index_buffer = render_engine.create_buffer(index_create_info, memory_resource);
+                    index_buffer = device.create_buffer(index_create_info, memory_resource);
                 }
 
                 return ntl::Result<bool>(true);
             })
             .on_error([](const ntl::NovaError& error) {
                 NOVA_LOG(ERROR) << "Could not allocate device memory for procedural mesh. Error: " << error.to_string();
+                // TODO: Propagate the error
             });
 
-        render_engine.allocate_device_memory(host_memory_size.b_count(), MemoryUsage::StagingBuffer, ObjectType::Buffer)
+        device.allocate_device_memory(host_memory_size.b_count(), MemoryUsage::StagingBuffer, ObjectType::Buffer)
             .map([&](DeviceMemory* memory) {
                 // TODO: Find a good way to keep these around
                 const auto
@@ -50,13 +57,114 @@ namespace nova::renderer {
                                                                                                        host_memory_size);
                 auto memory_resource = DeviceMemoryResource(memory, allocation_strategy.get());
 
-                cached_vertex_buffer = render_engine.create_buffer({vertex_buffer_size, BufferUsage::StagingBuffer}, memory_resource);
-                cached_index_buffer = render_engine.create_buffer({index_buffer_size, BufferUsage::StagingBuffer}, memory_resource);
+                cached_vertex_buffer = device.create_buffer({vertex_buffer_size, BufferUsage::StagingBuffer}, memory_resource);
+                cached_index_buffer = device.create_buffer({index_buffer_size, BufferUsage::StagingBuffer}, memory_resource);
 
                 return ntl::Result<bool>(true);
             })
             .on_error([](const ntl::NovaError& error) {
                 NOVA_LOG(ERROR) << "Could not allocate host memory for procedural mesh. Error: " << error.to_string();
+                // TODO: Propagate the error
             });
+    }
+
+    void ProceduralMesh::set_vertex_data(const void* data, const uint64_t size) {
+        render_engine.write_data_to_buffer(data, size, 0, cached_vertex_buffer);
+        num_vertex_bytes_to_upload = size;
+    }
+
+    void ProceduralMesh::set_index_data(const void* data, const uint64_t size) {
+        render_engine.write_data_to_buffer(data, size, 0, cached_index_buffer);
+        num_index_bytes_to_upload = size;
+    }
+
+    void ProceduralMesh::record_commands_to_upload_data(CommandList* cmds, const uint8_t frame_idx) {
+        const bool should_upload_vertex_buffer = num_vertex_bytes_to_upload > 0;
+        const bool should_upload_index_buffer = num_index_bytes_to_upload > 0;
+
+		auto* cur_vertex_buffer = vertex_buffers.at(frame_idx);
+		auto* cur_index_buffer = index_buffers.at(frame_idx);
+
+        std::vector<ResourceBarrier> barriers_before_upload;
+
+        if(should_upload_vertex_buffer) {
+            ResourceBarrier barrier_before_vertex_upload = {};
+            barrier_before_vertex_upload.resource_to_barrier = cur_vertex_buffer;
+            barrier_before_vertex_upload.access_before_barrier = AccessFlags::VertexAttributeRead;
+            barrier_before_vertex_upload.access_after_barrier = AccessFlags::MemoryWrite;
+            barrier_before_vertex_upload.old_state = ResourceState::VertexBuffer;
+            barrier_before_vertex_upload.new_state = ResourceState::CopyDestination;
+            barrier_before_vertex_upload.source_queue = QueueType::Graphics;
+            barrier_before_vertex_upload.destination_queue = QueueType::Transfer;
+            barrier_before_vertex_upload.buffer_memory_barrier.offset = 0;
+            barrier_before_vertex_upload.buffer_memory_barrier.size = num_vertex_bytes_to_upload;
+
+            barriers_before_upload.push_back(barrier_before_vertex_upload);
+        }
+
+        if(should_upload_index_buffer) {
+            ResourceBarrier barrier_before_index_upload = {};
+			barrier_before_index_upload.resource_to_barrier = cur_index_buffer;
+			barrier_before_index_upload.access_before_barrier = AccessFlags::IndexRead;
+			barrier_before_index_upload.access_after_barrier = AccessFlags::MemoryWrite;
+			barrier_before_index_upload.old_state = ResourceState::IndexBuffer;
+			barrier_before_index_upload.new_state = ResourceState::CopyDestination;
+			barrier_before_index_upload.source_queue = QueueType::Graphics;
+			barrier_before_index_upload.destination_queue = QueueType::Transfer;
+			barrier_before_index_upload.buffer_memory_barrier.offset = 0;
+			barrier_before_index_upload.buffer_memory_barrier.size = num_vertex_bytes_to_upload;
+
+			barriers_before_upload.push_back(barrier_before_index_upload);
+        }
+
+        if(barriers_before_upload.empty()) {
+            return;
+        }
+
+        cmds->resource_barriers(PipelineStageFlags::BottomOfPipe, PipelineStageFlags::Transfer, barriers_before_upload);
+
+        if(should_upload_vertex_buffer) {
+            cmds->copy_buffer(cur_vertex_buffer, 0, cached_vertex_buffer, 0, num_vertex_bytes_to_upload);
+        }
+
+        if(should_upload_index_buffer) {
+			cmds->copy_buffer(cur_index_buffer, 0, cached_index_buffer, 0, num_index_bytes_to_upload);
+        }
+
+        std::vector<ResourceBarrier> barriers_after_upload;
+
+        if(should_upload_vertex_buffer) {
+            ResourceBarrier barrier_after_vertex_upload = {};
+            barrier_after_vertex_upload.resource_to_barrier = cur_vertex_buffer;
+            barrier_after_vertex_upload.access_before_barrier = AccessFlags::MemoryWrite;
+            barrier_after_vertex_upload.access_after_barrier = AccessFlags::VertexAttributeRead;
+            barrier_after_vertex_upload.old_state = ResourceState::CopyDestination;
+            barrier_after_vertex_upload.new_state = ResourceState::VertexBuffer;
+            barrier_after_vertex_upload.source_queue = QueueType::Graphics;
+            barrier_after_vertex_upload.destination_queue = QueueType::Graphics;
+            barrier_after_vertex_upload.buffer_memory_barrier.offset = 0;
+            barrier_after_vertex_upload.buffer_memory_barrier.size = num_vertex_bytes_to_upload;
+            barriers_after_upload.push_back(barrier_after_vertex_upload);
+        }
+
+		if (should_upload_index_buffer) {
+			ResourceBarrier barrier_after_index_upload = {};
+			barrier_after_index_upload.resource_to_barrier = cur_index_buffer;
+			barrier_after_index_upload.access_before_barrier = AccessFlags::MemoryWrite;
+			barrier_after_index_upload.access_after_barrier = AccessFlags::IndexRead;
+			barrier_after_index_upload.old_state = ResourceState::CopyDestination;
+			barrier_after_index_upload.new_state = ResourceState::IndexBuffer;
+			barrier_after_index_upload.source_queue = QueueType::Graphics;
+			barrier_after_index_upload.destination_queue = QueueType::Graphics;
+			barrier_after_index_upload.buffer_memory_barrier.offset = 0;
+			barrier_after_index_upload.buffer_memory_barrier.size = num_index_bytes_to_upload;
+			barriers_after_upload.push_back(barrier_after_index_upload);
+		}
+
+		if (barriers_after_upload.empty()) {
+			return;
+		}
+
+        cmds->resource_barriers(PipelineStageFlags::Transfer, PipelineStageFlags::TopOfPipe, barriers_after_upload);
     }
 } // namespace nova::renderer

--- a/src/render_objects/procedural_mesh.cpp
+++ b/src/render_objects/procedural_mesh.cpp
@@ -2,19 +2,61 @@
 
 #include "nova_renderer/render_engine.hpp"
 
+#include "../memory/block_allocation_strategy.hpp"
+#include "../memory/mallocator.hpp"
+#include "../util/logger.hpp"
+#include "../util/memory_utils.hpp"
+
 namespace nova::renderer {
     using namespace rhi;
 
     ProceduralMesh::ProceduralMesh(uint64_t vertex_buffer_size, uint64_t index_buffer_size, rhi::RenderEngine& render_engine)
         : render_engine(render_engine) {
-        DeviceMemory* vertex_buffer_memory = render_engine.allocate_device_memory(vertex_buffer_size * 3,
-                                                                                  MemoryUsage::LowFrequencyUpload,
-                                                                                  ObjectType::Buffer);
+        const auto aligned_vertex_buffer_size = bvestl::polyalloc::align(vertex_buffer_size, 256);
+        const auto aligned_index_buffer_size = bvestl::polyalloc::align(index_buffer_size, 256);
+        const auto host_memory_size = aligned_vertex_buffer_size + aligned_index_buffer_size;
+        const auto device_memory_size = host_memory_size * 3;
 
-        BufferCreateInfo vertex_create_info = {vertex_buffer_size, BufferUsage::VertexBuffer};
+        // TODO: Don't allocate a separate device memory for each procedural mesh
+        render_engine.allocate_device_memory(device_memory_size.b_count(), MemoryUsage::LowFrequencyUpload, ObjectType::Buffer)
+            .map([&](DeviceMemory* memory) {
+                // TODO: Find a good way to keep these around
+                const auto
+                    allocation_strategy = std::make_unique<bvestl::polyalloc::BlockAllocationStrategy>(new bvestl::polyalloc::Mallocator(),
+                                                                                                       device_memory_size);
+                auto memory_resource = DeviceMemoryResource(memory, allocation_strategy.get());
 
-        for(uint32_t i = 0; i < vertex_buffers.size(); i++) {
-            vertex_buffers
-        }
+                const auto vertex_create_info = BufferCreateInfo{vertex_buffer_size, BufferUsage::VertexBuffer};
+                for(auto& vertex_buffer : vertex_buffers) {
+                    vertex_buffer = render_engine.create_buffer(vertex_create_info, memory_resource);
+                }
+
+                const auto index_create_info = BufferCreateInfo{index_buffer_size, BufferUsage::IndexBuffer};
+                for(auto& index_buffer : index_buffers) {
+                    index_buffer = render_engine.create_buffer(index_create_info, memory_resource);
+                }
+
+                return ntl::Result<bool>(true);
+            })
+            .on_error([](const ntl::NovaError& error) {
+                NOVA_LOG(ERROR) << "Could not allocate device memory for procedural mesh. Error: " << error.to_string();
+            });
+
+        render_engine.allocate_device_memory(host_memory_size.b_count(), MemoryUsage::StagingBuffer, ObjectType::Buffer)
+            .map([&](DeviceMemory* memory) {
+                // TODO: Find a good way to keep these around
+                const auto
+                    allocation_strategy = std::make_unique<bvestl::polyalloc::BlockAllocationStrategy>(new bvestl::polyalloc::Mallocator(),
+                                                                                                       host_memory_size);
+                auto memory_resource = DeviceMemoryResource(memory, allocation_strategy.get());
+
+                cached_vertex_buffer = render_engine.create_buffer({vertex_buffer_size, BufferUsage::StagingBuffer}, memory_resource);
+                cached_index_buffer = render_engine.create_buffer({index_buffer_size, BufferUsage::StagingBuffer}, memory_resource);
+
+                return ntl::Result<bool>(true);
+            })
+            .on_error([](const ntl::NovaError& error) {
+                NOVA_LOG(ERROR) << "Could not allocate host memory for procedural mesh. Error: " << error.to_string();
+            });
     }
 } // namespace nova::renderer

--- a/src/render_objects/render_object.cpp
+++ b/src/render_objects/render_object.cpp
@@ -1,3 +1,0 @@
-#include "render_object.hpp"
-
-namespace nova::renderer {} // namespace nova::renderer

--- a/src/render_objects/renderables.cpp
+++ b/src/render_objects/renderables.cpp
@@ -1,0 +1,19 @@
+#include "nova_renderer/renderables.hpp"
+
+#include <glm/ext/matrix_transform.inl>
+
+namespace nova::renderer {
+    StaticMeshRenderCommand make_render_command(const StaticMeshRenderableData& data, const RenderableId id) {
+        StaticMeshRenderCommand command = {};
+        command.id = id;
+        command.is_visible = true;
+        // TODO: Make sure this is accurate
+        command.model_matrix = glm::translate(command.model_matrix, data.initial_position);
+        command.model_matrix = glm::rotate(command.model_matrix, data.initial_rotation.x, { 1, 0, 0 });
+        command.model_matrix = glm::rotate(command.model_matrix, data.initial_rotation.y, { 0, 1, 0 });
+        command.model_matrix = glm::rotate(command.model_matrix, data.initial_rotation.z, { 0, 0, 1 });
+        command.model_matrix = glm::scale(command.model_matrix, data.initial_scale); // Uniform scaling only
+        
+        return command;
+    }
+}


### PR DESCRIPTION
I've added a procedural mesh class. This allows one to upload new mesh data every frame, facilitating highly dynamic geometry 

Currently ProceduralMesh uploads its data every frame. This is probably fine, but future work will profile and optimize so mesh data isn't uploaded unless needed

Procedural Meshes are owned by NovaRenderer. I created MapAccessor as a way to access an object in a map without knowing the map itself. This allows code external to NovaRenderer to set the mesh data of a procedural mesh

I've also renamed a few things to better match how the current code works - for instance, "renderable" is becoming "render command", and "render engine" is starting to become "render device" - although render device will be a separate PR

Finally, the frame index that a Swapchain returns is now a `uint8_t`. This better reflects that there will only ever be a small number of in-flight frames at a given time

Closes #223 