### PR TITLE
Unbounded arrays

### DIFF
--- a/include/nova_renderer/rhi_types.hpp
+++ b/include/nova_renderer/rhi_types.hpp
@@ -155,15 +155,27 @@ namespace nova::renderer::rhi {
         };
     };
 
-    struct DescriptorImageUpdate {
+    struct DescriptorImageInfo {
         const Image* image;
         shaderpack::TextureFormat format;
         Sampler* sampler;
     };
 
-    struct DescriptorBufferWrite {
+    struct DescriptorBufferInfo {
         const Buffer* buffer;
     };
+
+	union DescriptorResourceInfo {
+		/*!
+		 * \brief Information to update an image descriptor
+		 */
+		DescriptorImageInfo image_info;
+
+		/*!
+		 * \brief Information to update a buffer descriptor
+		 */
+		DescriptorBufferInfo buffer_info;
+	};
 
     struct DescriptorSetWrite {
         /*!
@@ -174,24 +186,17 @@ namespace nova::renderer::rhi {
         /*!
          * \brief The specific binding in the set that you want to write to
          */
-        uint32_t binding;
+        uint32_t first_binding;
 
         /*!
          * \brief The type of descriptor you're writing to
          */
         DescriptorType type;
 
-        union {
-            /*!
-             * \brief Information to update an image descriptor
-             */
-            DescriptorImageUpdate image_info;
-
-            /*!
-             * \brief Information to update a buffer descriptor
-             */
-            DescriptorBufferWrite buffer_info;
-        };
+        /*!
+         * \brief Information about th
+         */
+        std::vector<DescriptorResourceInfo> bindings;
     };
 #pragma endregion
 

--- a/include/nova_renderer/rhi_types.hpp
+++ b/include/nova_renderer/rhi_types.hpp
@@ -63,8 +63,17 @@ namespace nova::renderer::rhi {
 
         /*!
          * \brief Number of bindings. Useful if you have an array of descriptors
+         *
+         * If this is a unbounded array, this count is the upper limit on the size of the array
          */
         uint32_t count;
+
+        /*!
+         * \brief If true, this binding is an unbounded array
+         *
+         * Unbounded descriptors must be the final binding in their descriptor set
+         */
+        bool is_unbounded;
 
         /*!
          * \brief The type of object that will be bound

--- a/include/nova_renderer/rhi_types.hpp
+++ b/include/nova_renderer/rhi_types.hpp
@@ -156,13 +156,13 @@ namespace nova::renderer::rhi {
     };
 
     struct DescriptorImageInfo {
-        const Image* image;
+        Image* image;
         shaderpack::TextureFormat format;
         Sampler* sampler;
     };
 
     struct DescriptorBufferInfo {
-        const Buffer* buffer;
+        Buffer* buffer;
     };
 
 	union DescriptorResourceInfo {

--- a/include/nova_renderer/rhi_types.hpp
+++ b/include/nova_renderer/rhi_types.hpp
@@ -52,7 +52,7 @@ namespace nova::renderer::rhi {
 
     struct ResourceBindingDescription {
         /*!
-         * \brief Descriptor set that his binding belongs to
+         * \brief Descriptor set that this binding belongs to
          */
         uint32_t set;
 
@@ -194,9 +194,11 @@ namespace nova::renderer::rhi {
         DescriptorType type;
 
         /*!
-         * \brief Information about th
+         * \brief All the resources to bind to this descriptor
+         *
+         * You may only bind multiple resources if the descriptor is an array descriptor. Knowing whether you're binding to an array descriptor or not is your responsibility
          */
-        std::vector<DescriptorResourceInfo> bindings;
+        std::vector<DescriptorResourceInfo> resources;
     };
 #pragma endregion
 

--- a/include/nova_renderer/shaderpack_data.hpp
+++ b/include/nova_renderer/shaderpack_data.hpp
@@ -211,6 +211,11 @@ namespace nova::renderer::shaderpack {
 
     enum class TextureDimensionTypeEnum { ScreenRelative, Absolute };
 
+    enum class ImageUsage {
+        RenderTarget,
+        SampledImage,
+    };
+
     /*!
      * \brief Defines a sampler to use for a texture
      *
@@ -448,6 +453,8 @@ namespace nova::renderer::shaderpack {
          * If you use `Backbuffer`, then all fields are ignored since the backbuffer is always bound to output location 0
          */
         std::string name;
+
+        ImageUsage usage;
 
         TextureFormat format{};
     };

--- a/src/nova_renderer.cpp
+++ b/src/nova_renderer.cpp
@@ -634,6 +634,11 @@ namespace nova::renderer {
         new_binding.count = 1;
         new_binding.stages = shader_stage;
 
+        const spirv_cross::SPIRType& type_information = shader_compiler.get_type(resource.type_id);
+        if(!type_information.array.empty()) {
+            new_binding.count = type_information.array[0];
+        }
+
         const std::string& resource_name = resource.name;
 
         if(const auto itr = bindings.find(resource_name); itr != bindings.end()) {

--- a/src/nova_renderer.cpp
+++ b/src/nova_renderer.cpp
@@ -524,10 +524,10 @@ namespace nova::renderer {
             if(const auto dyn_tex_itr = dynamic_textures.find(resource_name); dyn_tex_itr != dynamic_textures.end()) {
                 rhi::Image* image = dyn_tex_itr->second;
 
-				resource_info.image_info.image = image;
-				resource_info.image_info.sampler = point_sampler;
-				resource_info.image_info.format = dynamic_texture_infos.at(resource_name).format;
-                
+                resource_info.image_info.image = image;
+                resource_info.image_info.sampler = point_sampler;
+                resource_info.image_info.format = dynamic_texture_infos.at(resource_name).format;
+
                 write.type = rhi::DescriptorType::CombinedImageSampler;
 
                 writes.push_back(write);
@@ -535,7 +535,7 @@ namespace nova::renderer {
             } else if(const auto builtin_buffer_itr = builtin_buffers.find(resource_name); builtin_buffer_itr != builtin_buffers.end()) {
                 rhi::Buffer* buffer = builtin_buffer_itr->second;
 
-				resource_info.buffer_info.buffer = buffer;
+                resource_info.buffer_info.buffer = buffer;
                 write.type = rhi::DescriptorType::UniformBuffer;
 
                 writes.push_back(write);
@@ -639,6 +639,8 @@ namespace nova::renderer {
         const spirv_cross::SPIRType& type_information = shader_compiler.get_type(resource.type_id);
         if(!type_information.array.empty()) {
             new_binding.count = type_information.array[0];
+            // All arrays are unbounded until I figure out how to use SPIRV-Cross to detect unbounded arrays
+            new_binding.is_unbounded = true;
         }
 
         const std::string& resource_name = resource.name;

--- a/src/nova_renderer.cpp
+++ b/src/nova_renderer.cpp
@@ -453,7 +453,6 @@ namespace nova::renderer {
                     }
                 }
             }
-
             renderpass.id = static_cast<uint32_t>(renderpass_metadatas.size());
 
             renderpasses.push_back(renderpass);

--- a/src/nova_renderer.cpp
+++ b/src/nova_renderer.cpp
@@ -517,22 +517,23 @@ namespace nova::renderer {
             rhi::DescriptorSetWrite write = {};
             write.set = descriptor_set;
             write.first_binding = binding_desc.binding;
+            rhi::DescriptorResourceInfo& resource_info = write.bindings.at(0);
 
             if(const auto dyn_tex_itr = dynamic_textures.find(resource_name); dyn_tex_itr != dynamic_textures.end()) {
-                const rhi::Image* image = dyn_tex_itr->second;
+                rhi::Image* image = dyn_tex_itr->second;
 
-                write.image_info.image = image;
-                write.image_info.sampler = point_sampler;
-                write.image_info.format = dynamic_texture_infos.at(resource_name).format;
+				resource_info.image_info.image = image;
+				resource_info.image_info.sampler = point_sampler;
+				resource_info.image_info.format = dynamic_texture_infos.at(resource_name).format;
                 
                 write.type = rhi::DescriptorType::CombinedImageSampler;
 
                 writes.push_back(write);
 
             } else if(const auto builtin_buffer_itr = builtin_buffers.find(resource_name); builtin_buffer_itr != builtin_buffers.end()) {
-                const rhi::Buffer* buffer = builtin_buffer_itr->second;
+                rhi::Buffer* buffer = builtin_buffer_itr->second;
 
-                write.buffer_info.buffer = buffer;
+				resource_info.buffer_info.buffer = buffer;
                 write.type = rhi::DescriptorType::UniformBuffer;
 
                 writes.push_back(write);

--- a/src/nova_renderer.cpp
+++ b/src/nova_renderer.cpp
@@ -519,7 +519,7 @@ namespace nova::renderer {
             rhi::DescriptorSetWrite write = {};
             write.set = descriptor_set;
             write.first_binding = binding_desc.binding;
-            rhi::DescriptorResourceInfo& resource_info = write.bindings.at(0);
+            rhi::DescriptorResourceInfo& resource_info = write.resources.at(0);
 
             if(const auto dyn_tex_itr = dynamic_textures.find(resource_name); dyn_tex_itr != dynamic_textures.end()) {
                 rhi::Image* image = dyn_tex_itr->second;

--- a/src/nova_renderer.cpp
+++ b/src/nova_renderer.cpp
@@ -69,6 +69,8 @@ namespace nova::renderer {
 
         MTR_SCOPE("Init", "nova_renderer::nova_renderer");
 
+        window = std::make_shared<NovaWindow>(settings);
+
         if(settings.debug.renderdoc.enabled) {
             MTR_SCOPE("Init", "LoadRenderdoc");
             auto rd_load_result = load_renderdoc(settings.debug.renderdoc.renderdoc_dll_path);

--- a/src/nova_renderer.cpp
+++ b/src/nova_renderer.cpp
@@ -519,7 +519,8 @@ namespace nova::renderer {
             rhi::DescriptorSetWrite write = {};
             write.set = descriptor_set;
             write.first_binding = binding_desc.binding;
-            rhi::DescriptorResourceInfo& resource_info = write.resources.at(0);
+            write.resources.emplace_back();
+            rhi::DescriptorResourceInfo& resource_info = write.resources[0];
 
             if(const auto dyn_tex_itr = dynamic_textures.find(resource_name); dyn_tex_itr != dynamic_textures.end()) {
                 rhi::Image* image = dyn_tex_itr->second;

--- a/src/nova_renderer.cpp
+++ b/src/nova_renderer.cpp
@@ -516,7 +516,7 @@ namespace nova::renderer {
 
             rhi::DescriptorSetWrite write = {};
             write.set = descriptor_set;
-            write.binding = binding_desc.binding;
+            write.first_binding = binding_desc.binding;
 
             if(const auto dyn_tex_itr = dynamic_textures.find(resource_name); dyn_tex_itr != dynamic_textures.end()) {
                 const rhi::Image* image = dyn_tex_itr->second;

--- a/src/render_engine/dx12/dx12_render_engine.cpp
+++ b/src/render_engine/dx12/dx12_render_engine.cpp
@@ -312,8 +312,8 @@ namespace nova::renderer::rhi {
 
             switch(write.type) {
                 case DescriptorType::CombinedImageSampler: {
-                    for(uint32_t i = 0; i < write.bindings.size(); i++) {
-                        const auto& binding = write.bindings.at(i);
+                    for(uint32_t i = 0; i < write.resources.size(); i++) {
+                        const auto& binding = write.resources.at(i);
                         const auto* image = static_cast<const DX12Image*>(binding.image_info.image);
 
                         write_handle.Offset(i, cbv_srv_uav_descriptor_size);
@@ -331,8 +331,8 @@ namespace nova::renderer::rhi {
                 } break;
 
                 case DescriptorType::UniformBuffer: {
-                    for(uint32_t i = 0; i < write.bindings.size(); i++) {
-                        const auto& binding = write.bindings.at(i);
+                    for(uint32_t i = 0; i < write.resources.size(); i++) {
+                        const auto& binding = write.resources.at(i);
                         const auto* buffer = static_cast<const DX12Buffer*>(binding.buffer_info.buffer);
 
                         write_handle.Offset(i, cbv_srv_uav_descriptor_size);

--- a/src/render_engine/gl3/gl3_render_engine.cpp
+++ b/src/render_engine/gl3/gl3_render_engine.cpp
@@ -144,18 +144,18 @@ namespace nova::renderer::rhi {
             switch(write.type) {
                 case DescriptorType::CombinedImageSampler: {
                     for(uint32_t i = 0; i < write.bindings.size(); i++) {
-						Gl3Descriptor& descriptor = set->descriptors.at(write.first_binding + i);
+                        Gl3Descriptor& descriptor = set->descriptors.at(write.first_binding + i);
                         auto* image = static_cast<Gl3Image*>(write.bindings.at(i).image_info.image);
                         descriptor.resource = image;
                     }
                 } break;
 
                 case DescriptorType::UniformBuffer: {
-					for (uint32_t i = 0; i < write.bindings.size(); i++) {
-						Gl3Descriptor& descriptor = set->descriptors.at(write.first_binding + i);
-						auto* buffer = static_cast<Gl3Buffer*>(write.bindings.at(i).buffer_info.buffer);
-						descriptor.resource = buffer;
-					}
+                    for(uint32_t i = 0; i < write.bindings.size(); i++) {
+                        Gl3Descriptor& descriptor = set->descriptors.at(write.first_binding + i);
+                        auto* buffer = static_cast<Gl3Buffer*>(write.bindings.at(i).buffer_info.buffer);
+                        descriptor.resource = buffer;
+                    }
 
                 } break;
 

--- a/src/render_engine/gl3/gl3_render_engine.cpp
+++ b/src/render_engine/gl3/gl3_render_engine.cpp
@@ -143,17 +143,17 @@ namespace nova::renderer::rhi {
 
             switch(write.type) {
                 case DescriptorType::CombinedImageSampler: {
-                    for(uint32_t i = 0; i < write.bindings.size(); i++) {
+                    for(uint32_t i = 0; i < write.resources.size(); i++) {
                         Gl3Descriptor& descriptor = set->descriptors.at(write.first_binding + i);
-                        auto* image = static_cast<Gl3Image*>(write.bindings.at(i).image_info.image);
+                        auto* image = static_cast<Gl3Image*>(write.resources.at(i).image_info.image);
                         descriptor.resource = image;
                     }
                 } break;
 
                 case DescriptorType::UniformBuffer: {
-                    for(uint32_t i = 0; i < write.bindings.size(); i++) {
+                    for(uint32_t i = 0; i < write.resources.size(); i++) {
                         Gl3Descriptor& descriptor = set->descriptors.at(write.first_binding + i);
-                        auto* buffer = static_cast<Gl3Buffer*>(write.bindings.at(i).buffer_info.buffer);
+                        auto* buffer = static_cast<Gl3Buffer*>(write.resources.at(i).buffer_info.buffer);
                         descriptor.resource = buffer;
                     }
 

--- a/src/render_engine/gl3/gl3_render_engine.cpp
+++ b/src/render_engine/gl3/gl3_render_engine.cpp
@@ -139,22 +139,23 @@ namespace nova::renderer::rhi {
 
     void Gl4NvRenderEngine::update_descriptor_sets(std::vector<DescriptorSetWrite>& writes) {
         for(DescriptorSetWrite& write : writes) {
-            const auto* const_set = static_cast<const Gl3DescriptorSet*>(write.set);
-            auto* set = const_cast<Gl3DescriptorSet*>(const_set); // I have a few regrets
-            Gl3Descriptor& descriptor = set->descriptors.at(write.binding);
+            auto* set = static_cast<Gl3DescriptorSet*>(write.set);
 
             switch(write.type) {
-
                 case DescriptorType::CombinedImageSampler: {
-                    const auto* cimage = static_cast<const Gl3Image*>(write.image_info.image);
-                    auto* image = const_cast<Gl3Image*>(cimage);
-                    descriptor.resource = image;
+                    for(uint32_t i = 0; i < write.bindings.size(); i++) {
+						Gl3Descriptor& descriptor = set->descriptors.at(write.first_binding + i);
+                        auto* image = static_cast<Gl3Image*>(write.bindings.at(i).image_info.image);
+                        descriptor.resource = image;
+                    }
                 } break;
 
                 case DescriptorType::UniformBuffer: {
-                    const auto* cbuffer = static_cast<const Gl3Buffer*>(write.buffer_info.buffer);
-                    auto* buffer = const_cast<Gl3Buffer*>(cbuffer);
-                    descriptor.resource = buffer;
+					for (uint32_t i = 0; i < write.bindings.size(); i++) {
+						Gl3Descriptor& descriptor = set->descriptors.at(write.first_binding + i);
+						auto* buffer = static_cast<Gl3Buffer*>(write.bindings.at(i).buffer_info.buffer);
+						descriptor.resource = buffer;
+					}
 
                 } break;
 

--- a/src/render_engine/gl3/gl3_render_engine.hpp
+++ b/src/render_engine/gl3/gl3_render_engine.hpp
@@ -20,6 +20,9 @@ namespace nova::renderer::rhi {
      * \brief OpenGL 4.5 RHI backend. Optimized for Nvidia GPUs
      */
     class Gl4NvRenderEngine final : public RenderEngine {
+        // Some optimizations that still need to happen:
+        // - Compile shaders to ARB assembly in 1500 ms or less
+        // - Only one VAO
     public:
         Gl4NvRenderEngine(NovaSettingsAccessManager& settings, const std::shared_ptr<NovaWindow>& window);
 

--- a/src/render_engine/vulkan/vulkan_render_engine.cpp
+++ b/src/render_engine/vulkan/vulkan_render_engine.cpp
@@ -302,7 +302,7 @@ namespace nova::renderer::rhi {
 
         auto* framebuffer = new_object<VulkanFramebuffer>();
         framebuffer->size = framebuffer_size;
-        framebuffer->num_attachments = static_cast<uint32_t>(color_attachments.size());
+        framebuffer->num_attachments = static_cast<uint32_t>(attachment_views.size());
 
         NOVA_CHECK_RESULT(vkCreateFramebuffer(device, &framebuffer_create_info, nullptr, &framebuffer->framebuffer));
 
@@ -1265,7 +1265,7 @@ namespace nova::renderer::rhi {
     }
 
     void VulkanRenderEngine::create_device_and_queues() {
-        static std::vector<std::string> device_extensions = { VK_KHR_SWAPCHAIN_EXTENSION_NAME, VK_EXT_DESCRIPTOR_INDEXING_EXTENSION_NAME };
+        static std::vector<char*> device_extensions = { VK_KHR_SWAPCHAIN_EXTENSION_NAME, VK_EXT_DESCRIPTOR_INDEXING_EXTENSION_NAME };
 
         uint32_t device_count;
         NOVA_CHECK_RESULT(vkEnumeratePhysicalDevices(instance, &device_count, nullptr));
@@ -1549,7 +1549,7 @@ namespace nova::renderer::rhi {
             binding_flags.pBindingFlags = flags.data();
             flag_infos.emplace_back(binding_flags);
 
-            create_info.pNext = &(*flag_infos.end());
+            create_info.pNext = &flag_infos[flag_infos.size() - 1];
 
             dsl_create_infos.push_back(create_info);
         }

--- a/src/render_engine/vulkan/vulkan_render_engine.cpp
+++ b/src/render_engine/vulkan/vulkan_render_engine.cpp
@@ -518,12 +518,12 @@ namespace nova::renderer::rhi {
                                    std::back_insert_iterator<std::vector<VkDescriptorImageInfo>>(image_infos),
                                    [&](const DescriptorResourceInfo& info) {
                                        VkDescriptorImageInfo vk_image_info = {};
-									   vk_image_info.imageView = image_view_for_image(info.image_info.image);
+                                       vk_image_info.imageView = image_view_for_image(info.image_info.image);
                                        vk_image_info.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
                                        vk_image_info.sampler = static_cast<VulkanSampler*>(info.image_info.sampler)->sampler;
                                        return vk_image_info;
                                    });
-                    
+
                     vk_write.descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
                     vk_write.pImageInfo = &image_infos[write_begin_idx];
 
@@ -531,25 +531,25 @@ namespace nova::renderer::rhi {
                 } break;
 
                 case DescriptorType::UniformBuffer: {
-					const auto write_begin_idx = image_infos.size();
+                    const auto write_begin_idx = image_infos.size();
 
-					std::transform(write.bindings.begin(),
-						write.bindings.end(),
-						std::back_insert_iterator<std::vector<VkDescriptorBufferInfo>>(buffer_infos),
-						[&](const DescriptorResourceInfo& info) {
-							const auto* vk_buffer = static_cast<const VulkanBuffer*>(info.buffer_info.buffer);
+                    std::transform(write.bindings.begin(),
+                                   write.bindings.end(),
+                                   std::back_insert_iterator<std::vector<VkDescriptorBufferInfo>>(buffer_infos),
+                                   [&](const DescriptorResourceInfo& info) {
+                                       const auto* vk_buffer = static_cast<const VulkanBuffer*>(info.buffer_info.buffer);
 
-							VkDescriptorBufferInfo vk_buffer_info = {};
-							vk_buffer_info.buffer = vk_buffer->buffer;
-							vk_buffer_info.offset = vk_buffer->memory.allocation_info.offset.b_count();
-							vk_buffer_info.range = vk_buffer->memory.allocation_info.size.b_count();
-							return vk_buffer_info;
-						});
+                                       VkDescriptorBufferInfo vk_buffer_info = {};
+                                       vk_buffer_info.buffer = vk_buffer->buffer;
+                                       vk_buffer_info.offset = vk_buffer->memory.allocation_info.offset.b_count();
+                                       vk_buffer_info.range = vk_buffer->memory.allocation_info.size.b_count();
+                                       return vk_buffer_info;
+                                   });
 
-					vk_write.descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
-					vk_write.pBufferInfo = &buffer_infos[write_begin_idx];
+                    vk_write.descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
+                    vk_write.pBufferInfo = &buffer_infos[write_begin_idx];
 
-					vk_writes.push_back(vk_write);
+                    vk_writes.push_back(vk_write);
                 } break;
 
                 case DescriptorType::StorageBuffer: {

--- a/src/render_engine/vulkan/vulkan_render_engine.cpp
+++ b/src/render_engine/vulkan/vulkan_render_engine.cpp
@@ -506,7 +506,7 @@ namespace nova::renderer::rhi {
             vk_write.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
             vk_write.dstSet = static_cast<const VulkanDescriptorSet*>(write.set)->descriptor_set;
             vk_write.dstBinding = write.first_binding;
-            vk_write.descriptorCount = write.bindings.size();
+            vk_write.descriptorCount = static_cast<uint32_t>(write.bindings.size());
             vk_write.dstArrayElement = 0;
 
             switch(write.type) {
@@ -1520,7 +1520,7 @@ namespace nova::renderer::rhi {
         std::vector<VkDescriptorSetLayoutCreateInfo> dsl_create_infos = {};
         dsl_create_infos.reserve(bindings_by_set.size());
 
-        std::vector<VkDescriptorSetLayoutCreateInfo> flag_infos = {};
+        std::vector<VkDescriptorSetLayoutBindingFlagsCreateInfoEXT> flag_infos = {};
         flag_infos.reserve(bindings_by_set.size());
 
         for(const auto& bindings : bindings_by_set) {

--- a/src/render_engine/vulkan/vulkan_render_engine.cpp
+++ b/src/render_engine/vulkan/vulkan_render_engine.cpp
@@ -1359,6 +1359,15 @@ namespace nova::renderer::rhi {
             device_create_info.ppEnabledLayerNames = enabled_layer_names.data();
         }
 
+        // Set up descriptor indexing
+		// Currently Nova only cares about indexing for texture descriptors
+        VkPhysicalDeviceDescriptorIndexingFeaturesEXT descriptor_indexing_features = {};
+        descriptor_indexing_features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES_EXT;
+		descriptor_indexing_features.shaderSampledImageArrayNonUniformIndexing = VK_TRUE;
+		descriptor_indexing_features.runtimeDescriptorArray = true;
+        descriptor_indexing_features.descriptorBindingVariableDescriptorCount = VK_TRUE;
+        device_create_info.pNext = &descriptor_indexing_features;
+
         NOVA_CHECK_RESULT(vkCreateDevice(gpu.phys_device, &device_create_info, nullptr, &device));
 
         graphics_family_index = graphics_family_idx;

--- a/src/render_engine/vulkan/vulkan_render_engine.cpp
+++ b/src/render_engine/vulkan/vulkan_render_engine.cpp
@@ -1158,6 +1158,8 @@ namespace nova::renderer::rhi {
 #error Unsupported Operating system
 #endif
 
+        enabled_extension_names.push_back(VK_EXT_DESCRIPTOR_INDEXING_EXTENSION_NAME);
+
         std::vector<VkValidationFeatureEnableEXT> enabled_validation_features = {VK_VALIDATION_FEATURE_ENABLE_BEST_PRACTICES_EXT};
 
         if(settings.settings.debug.enabled) {

--- a/src/render_engine/vulkan/vulkan_render_engine.cpp
+++ b/src/render_engine/vulkan/vulkan_render_engine.cpp
@@ -506,15 +506,15 @@ namespace nova::renderer::rhi {
             vk_write.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
             vk_write.dstSet = static_cast<const VulkanDescriptorSet*>(write.set)->descriptor_set;
             vk_write.dstBinding = write.first_binding;
-            vk_write.descriptorCount = static_cast<uint32_t>(write.bindings.size());
+            vk_write.descriptorCount = static_cast<uint32_t>(write.resources.size());
             vk_write.dstArrayElement = 0;
 
             switch(write.type) {
                 case DescriptorType::CombinedImageSampler: {
                     const auto write_begin_idx = image_infos.size();
 
-                    std::transform(write.bindings.begin(),
-                                   write.bindings.end(),
+                    std::transform(write.resources.begin(),
+                                   write.resources.end(),
                                    std::back_insert_iterator<std::vector<VkDescriptorImageInfo>>(image_infos),
                                    [&](const DescriptorResourceInfo& info) {
                                        VkDescriptorImageInfo vk_image_info = {};
@@ -533,8 +533,8 @@ namespace nova::renderer::rhi {
                 case DescriptorType::UniformBuffer: {
                     const auto write_begin_idx = image_infos.size();
 
-                    std::transform(write.bindings.begin(),
-                                   write.bindings.end(),
+                    std::transform(write.resources.begin(),
+                                   write.resources.end(),
                                    std::back_insert_iterator<std::vector<VkDescriptorBufferInfo>>(buffer_infos),
                                    [&](const DescriptorResourceInfo& info) {
                                        const auto* vk_buffer = static_cast<const VulkanBuffer*>(info.buffer_info.buffer);

--- a/src/render_engine/vulkan/vulkan_render_engine.cpp
+++ b/src/render_engine/vulkan/vulkan_render_engine.cpp
@@ -537,7 +537,7 @@ namespace nova::renderer::rhi {
 						write.bindings.end(),
 						std::back_insert_iterator<std::vector<VkDescriptorBufferInfo>>(buffer_infos),
 						[&](const DescriptorResourceInfo& info) {
-							const VulkanBuffer* vk_buffer = static_cast<const VulkanBuffer*>(info.buffer_info.buffer);
+							const auto* vk_buffer = static_cast<const VulkanBuffer*>(info.buffer_info.buffer);
 
 							VkDescriptorBufferInfo vk_buffer_info = {};
 							vk_buffer_info.buffer = vk_buffer->buffer;

--- a/src/render_engine/vulkan/vulkan_render_engine.cpp
+++ b/src/render_engine/vulkan/vulkan_render_engine.cpp
@@ -1461,7 +1461,7 @@ namespace nova::renderer::rhi {
         if(!required.empty()) {
             std::stringstream ss;
             for(const auto& extension : required) {
-                ss << extension;
+                ss << extension << ", ";
             }
 
             NOVA_LOG(WARN) << "Device does not support these required extensions: " << ss.str();

--- a/src/render_engine/vulkan/vulkan_render_engine.cpp
+++ b/src/render_engine/vulkan/vulkan_render_engine.cpp
@@ -1,12 +1,14 @@
 #include "vulkan_render_engine.hpp"
 
 #include <csignal>
-#include <set>
+#include <unordered_set>
 
 #include "nova_renderer/allocation_structs.hpp"
+#include "nova_renderer/constants.hpp"
 #include "nova_renderer/window.hpp"
 
 #include "../../util/logger.hpp"
+#include "../../util/memory_utils.hpp"
 #include "vk_structs.hpp"
 #include "vulkan_command_list.hpp"
 #include "vulkan_utils.hpp"
@@ -20,10 +22,6 @@
 #include "nova_renderer/util/windows.hpp"
 
 #endif
-
-#include "nova_renderer/constants.hpp"
-
-#include "../../util/memory_utils.hpp"
 
 namespace nova::renderer::rhi {
     VulkanRenderEngine::VulkanRenderEngine(NovaSettingsAccessManager& settings, const std::shared_ptr<NovaWindow>& window)
@@ -903,15 +901,15 @@ namespace nova::renderer::rhi {
                 barrier.subresourceRange.aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT;
 
                 vkCmdPipelineBarrier(cmds->cmds,
-                    VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT,
-                    VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT,
-                    0,
-                    0,
-                    nullptr,
-                    0,
-                    nullptr,
-                    1,
-                    &barrier);
+                                     VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT,
+                                     VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT,
+                                     0,
+                                     0,
+                                     nullptr,
+                                     0,
+                                     nullptr,
+                                     1,
+                                     &barrier);
 
             } else {
                 barrier.newLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
@@ -920,21 +918,21 @@ namespace nova::renderer::rhi {
                 barrier.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
 
                 vkCmdPipelineBarrier(cmds->cmds,
-                    VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
-                    VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
-                    0,
-                    0,
-                    nullptr,
-                    0,
-                    nullptr,
-                    1,
-                    &barrier);
+                                     VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
+                                     VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
+                                     0,
+                                     0,
+                                     nullptr,
+                                     0,
+                                     nullptr,
+                                     1,
+                                     &barrier);
             }
 
             Fence* fence = create_fence();
             submit_command_list(list, QueueType::Graphics, fence, {}, {});
 
-            wait_for_fences({ fence });
+            wait_for_fences({fence});
 
             VkImageViewCreateInfo image_view_create_info = {};
             image_view_create_info.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
@@ -1449,7 +1447,7 @@ namespace nova::renderer::rhi {
         std::vector<VkExtensionProperties> available(extension_count);
         vkEnumerateDeviceExtensionProperties(device, nullptr, &extension_count, available.data());
 
-        std::set<std::string> required;
+        std::unordered_set<std::string> required;
         for(const auto* extension : required_device_extensions) {
             required.emplace(extension);
         }

--- a/src/render_engine/vulkan/vulkan_render_engine.hpp
+++ b/src/render_engine/vulkan/vulkan_render_engine.hpp
@@ -167,7 +167,7 @@ namespace nova::renderer::rhi {
 
         void create_device_and_queues();
 
-        static bool does_device_support_extensions(VkPhysicalDevice device);
+        static bool does_device_support_extensions(VkPhysicalDevice device, const std::vector<char*>& required_device_extensions);
 
         void create_swapchain();
 

--- a/src/render_engine/vulkan/vulkan_swapchain.cpp
+++ b/src/render_engine/vulkan/vulkan_swapchain.cpp
@@ -272,7 +272,9 @@ namespace nova::renderer::rhi {
 
         info.clipped = VK_TRUE;
 
-        vkCreateSwapchainKHR(render_engine.device, &info, nullptr, &swapchain);
+        auto res = vkCreateSwapchainKHR(render_engine.device, &info, nullptr, &swapchain);
+
+        NOVA_LOG(ERROR) << res;
 
         swapchain_format = surface_format.format;
         this->present_mode = present_mode;

--- a/src/windowing/window.cpp
+++ b/src/windowing/window.cpp
@@ -62,6 +62,9 @@ namespace nova::renderer {
             if(options.debug.enabled) {
                 glfwWindowHint(GLFW_OPENGL_DEBUG_CONTEXT, GLFW_TRUE);
             }
+
+        } else {
+            glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API);
         }
 
         window = glfwCreateWindow(static_cast<int>(options.window.width),

--- a/tests/resources/shaderpacks/DefaultShaderpack/shaders/gbuffers_terrain.vert
+++ b/tests/resources/shaderpacks/DefaultShaderpack/shaders/gbuffers_terrain.vert
@@ -62,6 +62,8 @@ layout(set = 0, binding = 0) readonly buffer per_model_uniforms {
     mat4 modelMatrices[];
 };
 
+layout(set = 0, binding = 1) uniform texture2D font_textures[];
+
 layout(location = 0) out vec2 uv;
 layout(location = 1) out vec4 color;
 layout(location = 2) out vec2 lightmap_uv;

--- a/tests/src/end_to_end_runner.cpp
+++ b/tests/src/end_to_end_runner.cpp
@@ -35,7 +35,7 @@ namespace nova::renderer {
         NOVA_LOG(DEBUG) << "Predefined resources at: " << CMAKE_DEFINED_RESOURCES_PREFIX;
 
         NovaSettings settings;
-        settings.api = GraphicsApi::D3D12;
+        settings.api = GraphicsApi::Vulkan;
         settings.vulkan.application_name = "Nova Renderer test";
         settings.vulkan.application_version = {0, 9, 0};
         settings.debug.enabled = true;

--- a/tests/src/end_to_end_runner.cpp
+++ b/tests/src/end_to_end_runner.cpp
@@ -35,7 +35,7 @@ namespace nova::renderer {
         NOVA_LOG(DEBUG) << "Predefined resources at: " << CMAKE_DEFINED_RESOURCES_PREFIX;
 
         NovaSettings settings;
-        settings.api = GraphicsApi::Vulkan;
+        settings.api = GraphicsApi::D3D12;
         settings.vulkan.application_name = "Nova Renderer test";
         settings.vulkan.application_version = {0, 9, 0};
         settings.debug.enabled = true;

--- a/tests/src/end_to_end_runner.cpp
+++ b/tests/src/end_to_end_runner.cpp
@@ -52,22 +52,24 @@ namespace nova::renderer {
 
         MeshData cube = {};
         cube.vertex_data = {
-                FullVertex{{-1, -1, -1}, {}, {}, {}, {}, {}, {}},
-                FullVertex{{-1, -1, 1}, {}, {}, {}, {}, {}, {}},
-                FullVertex{{-1, 1, -1}, {}, {}, {}, {}, {}, {}},
-                FullVertex{{-1, 1, 1}, {}, {}, {}, {}, {}, {}},
-                FullVertex{{1, -1, -1}, {}, {}, {}, {}, {}, {}},
-                FullVertex{{1, -1, 1}, {}, {}, {}, {}, {}, {}},
-                FullVertex{{1, 1, -1}, {}, {}, {}, {}, {}, {}},
-                FullVertex{{1, 1, 1}, {}, {}, {}, {}, {}, {}},
-                };
+            FullVertex{{-1, -1, -1}, {}, {}, {}, {}, {}, {}},
+            FullVertex{{-1, -1, 1}, {}, {}, {}, {}, {}, {}},
+            FullVertex{{-1, 1, -1}, {}, {}, {}, {}, {}, {}},
+            FullVertex{{-1, 1, 1}, {}, {}, {}, {}, {}, {}},
+            FullVertex{{1, -1, -1}, {}, {}, {}, {}, {}, {}},
+            FullVertex{{1, -1, 1}, {}, {}, {}, {}, {}, {}},
+            FullVertex{{1, 1, -1}, {}, {}, {}, {}, {}, {}},
+            FullVertex{{1, 1, 1}, {}, {}, {}, {}, {}, {}},
+        };
         cube.indices = {0, 1, 3, 6, 0, 2, 5, 0, 4, 6, 4, 0, 0, 3, 2, 5, 1, 0, 3, 1, 5, 7, 4, 6, 4, 7, 5, 7, 6, 2, 7, 2, 3, 7, 3, 5};
 
         const MeshId mesh_id = renderer->create_mesh(cube);
 
         // Render one frame to upload mesh data
         renderer->execute_frame();
-        window->swap_backbuffer();
+        if(settings.api == GraphicsApi::NvGl4) {
+            window->swap_backbuffer();
+        }
 
         StaticMeshRenderableData data = {};
         data.mesh = mesh_id;
@@ -75,9 +77,11 @@ namespace nova::renderer {
 
         renderer->add_renderable_for_material(FullMaterialPassName{"gbuffers_terrain", "forward"}, data);
 
-        while (!window->should_close()) {
+        while(!window->should_close()) {
             renderer->execute_frame();
-            window->swap_backbuffer();
+            if(settings.api == GraphicsApi::NvGl4) {
+                window->swap_backbuffer();
+            }
         }
 
         NovaRenderer::deinitialize();


### PR DESCRIPTION
This PR adds support for unbounded uniform arrays to the Vulkan and D3D12 backends. This allows for the CPU to create an array of unknown size of e.g. texture handles. This is useful for highly dynamic situations where the number of textures isn't known ahead of time