### PR TITLE
Convert Vulkan RHI backend to Rex::Core

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,6 +116,7 @@ set(NOVA_SOURCE
 
         include/nova_renderer/rhi/forward_decls.hpp
         include/nova_renderer/rhi/command_list.hpp
+        include/nova_renderer/rhi/swapchain.hpp
         include/nova_renderer/rhi/rhi_enums.hpp
         include/nova_renderer/rhi/rhi_types.hpp
         include/nova_renderer/rhi/render_device.hpp

--- a/include/nova_renderer/rhi/command_list.hpp
+++ b/include/nova_renderer/rhi/command_list.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
-#include <cstdint> // needed for uint****
-#include <vector>
+#include <stdint.h> // needed for uint****
 
 #include "nova_renderer/rhi/forward_decls.hpp"
 #include "nova_renderer/rhi/rhi_enums.hpp"
@@ -49,7 +48,7 @@ namespace nova::renderer::rhi {
          */
         virtual void resource_barriers(PipelineStage stages_before_barrier,
                                        PipelineStage stages_after_barrier,
-                                       const std::pmr::vector<ResourceBarrier>& barriers) = 0;
+                                       const rx::vector<ResourceBarrier>& barriers) = 0;
 
         /*!
          * \brief Records a command to copy one region of a buffer to another buffer
@@ -95,7 +94,7 @@ namespace nova::renderer::rhi {
          * These command lists should be secondary command lists. Nova doesn't validate this because yolo but you need
          * to be nice - the API-specific validation layers _will_ yell at you
          */
-        virtual void execute_command_lists(const std::pmr::vector<CommandList*>& lists) = 0;
+        virtual void execute_command_lists(const rx::vector<CommandList*>& lists) = 0;
 
         /*!
          * \brief Begins a renderpass
@@ -109,7 +108,7 @@ namespace nova::renderer::rhi {
 
         virtual void bind_pipeline(const Pipeline* pipeline) = 0;
 
-        virtual void bind_descriptor_sets(const std::pmr::vector<DescriptorSet*>& descriptor_sets,
+        virtual void bind_descriptor_sets(const rx::vector<DescriptorSet*>& descriptor_sets,
                                           const PipelineInterface* pipeline_interface) = 0;
 
         /*!
@@ -120,7 +119,7 @@ namespace nova::renderer::rhi {
          *
          * \param buffers The buffers to bind
          */
-        virtual void bind_vertex_buffers(const std::pmr::vector<Buffer*>& buffers) = 0;
+        virtual void bind_vertex_buffers(const rx::vector<Buffer*>& buffers) = 0;
 
         /*!
          * \brief Binds the provided index buffer to the command list

--- a/include/nova_renderer/rhi/device_memory_resource.hpp
+++ b/include/nova_renderer/rhi/device_memory_resource.hpp
@@ -3,14 +3,11 @@
 #include "nova_renderer/memory/allocation_strategy.hpp"
 #include "nova_renderer/memory/allocation_structs.hpp"
 #include "nova_renderer/memory/bytes.hpp"
-#include "rhi_types.hpp"
+#include "nova_renderer/rhi/forward_decls.hpp"
+
 using namespace nova::mem::operators;
 
 namespace nova::renderer {
-    namespace rhi {
-        struct DeviceMemory;
-    }
-
     struct DeviceMemoryAllocation {
         rhi::DeviceMemory* memory = nullptr;
         mem::AllocationInfo allocation_info;

--- a/include/nova_renderer/rhi/render_device.hpp
+++ b/include/nova_renderer/rhi/render_device.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <rx/core/memory/system_allocator.h>
+
 #include "nova_renderer/nova_settings.hpp"
 #include "nova_renderer/rhi/command_list.hpp"
 #include "nova_renderer/rhi/rhi_types.hpp"
@@ -280,17 +282,17 @@ namespace nova::renderer::rhi {
                      NovaWindow& window,
                      rx::memory::allocator* allocator = &rx::memory::g_system_allocator);
 
-        template <typename ObjectType>
-        ObjectType* allocate_object(rx::memory::allocator* local_allocator);
+        template <typename ObjectType, typename... Args>
+        ObjectType* allocate_object(rx::memory::allocator* local_allocator, Args... args);
     };
 
-    template <typename ObjectType>
-    ObjectType* RenderDevice::allocate_object(rx::memory::allocator* local_allocator) {
+    template <typename ObjectType, typename... Args>
+    ObjectType* RenderDevice::allocate_object(rx::memory::allocator* local_allocator, Args... args) {
         return [&] {
             if(local_allocator != nullptr) {
-                return local_allocator->create<ObjectType>();
+                return local_allocator->create<ObjectType>(rx::utility::forward(args));
             } else {
-                return internal_allocator->create<ObjectType>();
+                return internal_allocator->create<ObjectType>(rx::utility::forward(args));
             }
         }();
     }

--- a/include/nova_renderer/rhi/render_device.hpp
+++ b/include/nova_renderer/rhi/render_device.hpp
@@ -290,9 +290,9 @@ namespace nova::renderer::rhi {
     ObjectType* RenderDevice::allocate_object(rx::memory::allocator* local_allocator, Args... args) {
         return [&] {
             if(local_allocator != nullptr) {
-                return local_allocator->create<ObjectType>(rx::utility::forward(args));
+                return local_allocator->create<ObjectType>(rx::utility::forward<Args>(args)...);
             } else {
-                return internal_allocator->create<ObjectType>(rx::utility::forward(args));
+                return internal_allocator->create<ObjectType>(rx::utility::forward<Args>(args)...);
             }
         }();
     }

--- a/include/nova_renderer/rhi/render_device.hpp
+++ b/include/nova_renderer/rhi/render_device.hpp
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <memory>
-
 #include "nova_renderer/memory/allocators.hpp"
 #include "nova_renderer/nova_settings.hpp"
 #include "nova_renderer/rhi/command_list.hpp"
@@ -79,7 +77,7 @@ namespace nova::renderer::rhi {
         [[nodiscard]] virtual ntl::Result<DeviceMemory*> allocate_device_memory(mem::Bytes size,
                                                                                 MemoryUsage type,
                                                                                 ObjectType allowed_objects,
-                                                                                mem::AllocatorHandle<>& allocator) = 0;
+                                                                                rx::memory::allocator* allocator = nullptr) = 0;
 
         /*!
          * \brief Creates a renderpass from the provided data
@@ -94,41 +92,41 @@ namespace nova::renderer::rhi {
          */
         [[nodiscard]] virtual ntl::Result<Renderpass*> create_renderpass(const shaderpack::RenderPassCreateInfo& data,
                                                                          const glm::uvec2& framebuffer_size,
-                                                                         mem::AllocatorHandle<>& allocator) = 0;
+                                                                         rx::memory::allocator* allocator = nullptr) = 0;
 
         [[nodiscard]] virtual Framebuffer* create_framebuffer(const Renderpass* renderpass,
-                                                              const std::pmr::vector<Image*>& color_attachments,
-                                                              const std::optional<Image*> depth_attachment,
+                                                              const rx::vector<Image*>& color_attachments,
+                                                              const rx::optional<Image*> depth_attachment,
                                                               const glm::uvec2& framebuffer_size,
-                                                              mem::AllocatorHandle<>& allocator) = 0;
+                                                              rx::memory::allocator* allocator = nullptr) = 0;
 
         [[nodiscard]] virtual ntl::Result<PipelineInterface*> create_pipeline_interface(
-            const std::unordered_map<std::string, ResourceBindingDescription>& bindings,
-            const std::pmr::vector<shaderpack::TextureAttachmentInfo>& color_attachments,
-            const std::optional<shaderpack::TextureAttachmentInfo>& depth_texture,
-            mem::AllocatorHandle<>& allocator) = 0;
+            const rx::map<rx::string, ResourceBindingDescription>& bindings,
+            const rx::vector<shaderpack::TextureAttachmentInfo>& color_attachments,
+            const rx::optional<shaderpack::TextureAttachmentInfo>& depth_texture,
+            rx::memory::allocator* allocator = nullptr) = 0;
 
         [[nodiscard]] virtual DescriptorPool* create_descriptor_pool(uint32_t num_sampled_images,
                                                                      uint32_t num_samplers,
                                                                      uint32_t num_uniform_buffers,
-                                                                     mem::AllocatorHandle<>& allocator) = 0;
+                                                                     rx::memory::allocator* allocator = nullptr) = 0;
 
-        [[nodiscard]] virtual std::pmr::vector<DescriptorSet*> create_descriptor_sets(const PipelineInterface* pipeline_interface,
-                                                                                      DescriptorPool* pool,
-                                                                                      mem::AllocatorHandle<>& allocator) = 0;
+        [[nodiscard]] virtual rx::vector<DescriptorSet*> create_descriptor_sets(const PipelineInterface* pipeline_interface,
+                                                                                DescriptorPool* pool,
+                                                                                rx::memory::allocator* allocator = nullptr) = 0;
 
-        virtual void update_descriptor_sets(std::pmr::vector<DescriptorSetWrite>& writes) = 0;
+        virtual void update_descriptor_sets(rx::vector<DescriptorSetWrite>& writes) = 0;
 
         [[nodiscard]] virtual ntl::Result<Pipeline*> create_pipeline(PipelineInterface* pipeline_interface,
                                                                      const shaderpack::PipelineCreateInfo& data,
-                                                                     mem::AllocatorHandle<>& allocator) = 0;
+                                                                     rx::memory::allocator* allocator = nullptr) = 0;
 
         /*!
          * \brief Creates a buffer with undefined contents
          */
         [[nodiscard]] virtual Buffer* create_buffer(const BufferCreateInfo& info,
                                                     DeviceMemoryResource& memory,
-                                                    mem::AllocatorHandle<>& allocator) = 0;
+                                                    rx::memory::allocator* allocator = nullptr) = 0;
 
         /*!
          * \brief Writes data to a buffer
@@ -151,18 +149,19 @@ namespace nova::renderer::rhi {
          *
          * Useful when you want a render target, or you want to initialize the image on your own
          */
-        [[nodiscard]] virtual Image* create_image(const shaderpack::TextureCreateInfo& info, mem::AllocatorHandle<>& allocator) = 0;
+        [[nodiscard]] virtual Image* create_image(const shaderpack::TextureCreateInfo& info,
+                                                  rx::memory::allocator* allocator = nullptr) = 0;
 
-        [[nodiscard]] virtual Semaphore* create_semaphore(mem::AllocatorHandle<>& allocator) = 0;
+        [[nodiscard]] virtual Semaphore* create_semaphore(rx::memory::allocator* allocator = nullptr) = 0;
 
-        [[nodiscard]] virtual std::pmr::vector<Semaphore*> create_semaphores(uint32_t num_semaphores,
-                                                                             mem::AllocatorHandle<>& allocator) = 0;
+        [[nodiscard]] virtual rx::vector<Semaphore*> create_semaphores(uint32_t num_semaphores,
+                                                                       rx::memory::allocator* allocator = nullptr) = 0;
 
-        [[nodiscard]] virtual Fence* create_fence(mem::AllocatorHandle<>& allocator, bool signaled = false) = 0;
+        [[nodiscard]] virtual Fence* create_fence(bool signaled = false, rx::memory::allocator* allocator = nullptr) = 0;
 
-        [[nodiscard]] virtual std::pmr::vector<Fence*> create_fences(mem::AllocatorHandle<>& allocator,
-                                                                     uint32_t num_fences,
-                                                                     bool signaled = false) = 0;
+        [[nodiscard]] virtual rx::vector<Fence*> create_fences(uint32_t num_fences,
+                                                               bool signaled = false,
+                                                               rx::memory::allocator* allocator = nullptr) = 0;
 
         /*!
          * \blocks the fence until all fences are signaled
@@ -171,9 +170,9 @@ namespace nova::renderer::rhi {
          *
          * \param fences All the fences to wait for
          */
-        virtual void wait_for_fences(std::pmr::vector<Fence*> fences) = 0;
+        virtual void wait_for_fences(rx::vector<Fence*> fences) = 0;
 
-        virtual void reset_fences(const std::pmr::vector<Fence*>& fences) = 0;
+        virtual void reset_fences(const rx::vector<Fence*>& fences) = 0;
 
         /*!
          * \brief Clean up any GPU objects a Renderpass may own
@@ -181,7 +180,7 @@ namespace nova::renderer::rhi {
          * While Renderpasses are per-shaderpack objects, and their CPU memory will be cleaned up when a new shaderpack is loaded, we still
          * need to clean up their GPU objects
          */
-        virtual void destroy_renderpass(Renderpass* pass, mem::AllocatorHandle<>& allocator) = 0;
+        virtual void destroy_renderpass(Renderpass* pass, rx::memory::allocator* allocator = nullptr) = 0;
 
         /*!
          * \brief Clean up any GPU objects a Framebuffer may own
@@ -189,7 +188,7 @@ namespace nova::renderer::rhi {
          * While Framebuffers are per-shaderpack objects, and their CPU memory will be cleaned up when a new shaderpack is loaded, we still
          * need to clean up their GPU objects
          */
-        virtual void destroy_framebuffer(Framebuffer* framebuffer, mem::AllocatorHandle<>& allocator) = 0;
+        virtual void destroy_framebuffer(Framebuffer* framebuffer, rx::memory::allocator* allocator = nullptr) = 0;
 
         /*!
          * \brief Clean up any GPU objects a PipelineInterface may own
@@ -197,7 +196,7 @@ namespace nova::renderer::rhi {
          * While PipelineInterfaces are per-shaderpack objects, and their CPU memory will be cleaned up when a new shaderpack is loaded, we
          * still need to clean up their GPU objects
          */
-        virtual void destroy_pipeline_interface(PipelineInterface* pipeline_interface, mem::AllocatorHandle<>& allocator) = 0;
+        virtual void destroy_pipeline_interface(PipelineInterface* pipeline_interface, rx::memory::allocator* allocator = nullptr) = 0;
 
         /*!
          * \brief Clean up any GPU objects a Pipeline may own
@@ -205,7 +204,7 @@ namespace nova::renderer::rhi {
          * While Pipelines are per-shaderpack objects, and their CPU memory will be cleaned up when a new shaderpack is loaded, we still
          * need to clean up their GPU objects
          */
-        virtual void destroy_pipeline(Pipeline* pipeline, mem::AllocatorHandle<>& allocator) = 0;
+        virtual void destroy_pipeline(Pipeline* pipeline, rx::memory::allocator* allocator = nullptr) = 0;
 
         /*!
          * \brief Clean up any GPU objects an Image may own
@@ -213,7 +212,7 @@ namespace nova::renderer::rhi {
          * While Images are per-shaderpack objects, and their CPU memory will be cleaned up when a new shaderpack is loaded, we still need
          * to clean up their GPU objects
          */
-        virtual void destroy_texture(Image* resource, mem::AllocatorHandle<>& allocator) = 0;
+        virtual void destroy_texture(Image* resource, rx::memory::allocator* allocator = nullptr) = 0;
 
         /*!
          * \brief Clean up any GPU objects a Semaphores may own
@@ -221,7 +220,7 @@ namespace nova::renderer::rhi {
          * While Semaphores are per-shaderpack objects, and their CPU memory will be cleaned up when a new shaderpack is loaded, we still
          * need to clean up their GPU objects
          */
-        virtual void destroy_semaphores(std::pmr::vector<Semaphore*>& semaphores, mem::AllocatorHandle<>& allocator) = 0;
+        virtual void destroy_semaphores(rx::vector<Semaphore*>& semaphores, rx::memory::allocator* allocator = nullptr) = 0;
 
         /*!
          * \brief Clean up any GPU objects a Fence may own
@@ -229,7 +228,7 @@ namespace nova::renderer::rhi {
          * While Fence are per-shaderpack objects, and their CPU memory will be cleaned up when a new shaderpack is loaded, we still need to
          * clean up their GPU objects
          */
-        virtual void destroy_fences(const std::pmr::vector<Fence*>& fences, mem::AllocatorHandle<>& allocator) = 0;
+        virtual void destroy_fences(const rx::vector<Fence*>& fences, rx::memory::allocator* allocator = nullptr) = 0;
 
         [[nodiscard]] Swapchain* get_swapchain() const;
 
@@ -247,16 +246,16 @@ namespace nova::renderer::rhi {
          * Command lists allocated by this method are returned ready to record commands into - the caller doesn't need
          * to begin the command list
          */
-        virtual CommandList* create_command_list(mem::AllocatorHandle<>& allocator,
-                                                 uint32_t thread_idx,
+        virtual CommandList* create_command_list(uint32_t thread_idx,
                                                  QueueType needed_queue_type,
-                                                 CommandList::Level level = CommandList::Level::Primary) = 0;
+                                                 CommandList::Level level = CommandList::Level::Primary,
+                                                 rx::memory::allocator* allocator = nullptr) = 0;
 
         virtual void submit_command_list(CommandList* cmds,
                                          QueueType queue,
                                          Fence* fence_to_signal = nullptr,
-                                         const std::pmr::vector<Semaphore*>& wait_semaphores = {},
-                                         const std::pmr::vector<Semaphore*>& signal_semaphores = {}) = 0;
+                                         const rx::vector<Semaphore*>& wait_semaphores = {},
+                                         const rx::vector<Semaphore*>& signal_semaphores = {}) = 0;
 
         [[nodiscard]] mem::AllocatorHandle<>* get_allocator() const;
 
@@ -278,9 +277,6 @@ namespace nova::renderer::rhi {
          *
          * \attention Called by the various render engine implementations
          */
-        RenderDevice(mem::AllocatorHandle<>& allocator, NovaSettingsAccessManager& settings, NovaWindow& window);
-
-
-
+        RenderDevice(NovaSettingsAccessManager& settings, NovaWindow& window, rx::memory::allocator* allocator = nullptr);
     };
 } // namespace nova::renderer::rhi

--- a/include/nova_renderer/rhi/render_device.hpp
+++ b/include/nova_renderer/rhi/render_device.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "nova_renderer/memory/allocators.hpp"
 #include "nova_renderer/nova_settings.hpp"
 #include "nova_renderer/rhi/command_list.hpp"
 #include "nova_renderer/rhi/rhi_types.hpp"
@@ -257,10 +256,10 @@ namespace nova::renderer::rhi {
                                          const rx::vector<Semaphore*>& wait_semaphores = {},
                                          const rx::vector<Semaphore*>& signal_semaphores = {}) = 0;
 
-        [[nodiscard]] mem::AllocatorHandle<>* get_allocator() const;
+        [[nodiscard]] rx::memory::allocator* get_allocator() const;
 
     protected:
-        mem::AllocatorHandle<>& internal_allocator;
+        rx::memory::allocator* internal_allocator;
 
         NovaWindow& window;
 
@@ -277,6 +276,8 @@ namespace nova::renderer::rhi {
          *
          * \attention Called by the various render engine implementations
          */
-        RenderDevice(NovaSettingsAccessManager& settings, NovaWindow& window, rx::memory::allocator* allocator = nullptr);
+        RenderDevice(NovaSettingsAccessManager& settings,
+                     NovaWindow& window,
+                     rx::memory::allocator* allocator = &rx::memory::g_system_allocator);
     };
 } // namespace nova::renderer::rhi

--- a/include/nova_renderer/rhi/render_device.hpp
+++ b/include/nova_renderer/rhi/render_device.hpp
@@ -279,5 +279,19 @@ namespace nova::renderer::rhi {
         RenderDevice(NovaSettingsAccessManager& settings,
                      NovaWindow& window,
                      rx::memory::allocator* allocator = &rx::memory::g_system_allocator);
+
+        template <typename ObjectType>
+        ObjectType* allocate_object(rx::memory::allocator* local_allocator);
     };
+
+    template <typename ObjectType>
+    ObjectType* RenderDevice::allocate_object(rx::memory::allocator* local_allocator) {
+        return [&] {
+            if(local_allocator != nullptr) {
+                return local_allocator->create<ObjectType>();
+            } else {
+                return internal_allocator->create<ObjectType>();
+            }
+        }();
+    }
 } // namespace nova::renderer::rhi

--- a/include/nova_renderer/rhi/rhi_types.hpp
+++ b/include/nova_renderer/rhi/rhi_types.hpp
@@ -102,7 +102,7 @@ namespace nova::renderer::rhi {
      * \brief The interface for a pipeline. Includes both inputs (descriptors) and outputs (framebuffers)
      */
     struct PipelineInterface {
-        rx::map<std::string, ResourceBindingDescription> bindings;
+        rx::map<rx::string, ResourceBindingDescription> bindings;
 
         rx::vector<VertexField> vertex_fields;
     };

--- a/include/nova_renderer/rhi/rhi_types.hpp
+++ b/include/nova_renderer/rhi/rhi_types.hpp
@@ -1,8 +1,5 @@
 #pragma once
 
-#include <string>
-#include <unordered_map>
-
 #include <glm/glm.hpp>
 
 #include "nova_renderer/memory/allocators.hpp"
@@ -96,7 +93,7 @@ namespace nova::renderer::rhi {
     };
 
     struct VertexField {
-        std::string name;
+        rx::string name;
 
         VertexFieldFormat format;
     };
@@ -105,9 +102,9 @@ namespace nova::renderer::rhi {
      * \brief The interface for a pipeline. Includes both inputs (descriptors) and outputs (framebuffers)
      */
     struct PipelineInterface {
-        std::unordered_map<std::string, ResourceBindingDescription> bindings;
+        rx::map<std::string, ResourceBindingDescription> bindings;
 
-        std::pmr::vector<VertexField> vertex_fields;
+        rx::vector<VertexField> vertex_fields;
     };
 
     struct Pipeline {};
@@ -215,7 +212,7 @@ namespace nova::renderer::rhi {
          * You may only bind multiple resources if the descriptor is an array descriptor. Knowing whether you're binding to an array
          * descriptor or not is your responsibility
          */
-        std::pmr::vector<DescriptorResourceInfo> resources;
+        rx::vector<DescriptorResourceInfo> resources;
     };
 #pragma endregion
 

--- a/include/nova_renderer/rhi/swapchain.hpp
+++ b/include/nova_renderer/rhi/swapchain.hpp
@@ -1,9 +1,8 @@
 #pragma once
-#include <vector>
-
 #include <glm/glm.hpp>
 
-#include "nova_renderer/memory/allocators.hpp"
+#include <rx/core/vector.h>
+#include <rx/core/memory/allocator.h>
 
 namespace nova::renderer::rhi {
     struct Fence;
@@ -22,7 +21,7 @@ namespace nova::renderer::rhi {
          *
          * \return The index of the swapchain image we just acquired
          */
-        virtual uint8_t acquire_next_swapchain_image(mem::AllocatorHandle<>& allocator) = 0;
+        virtual uint8_t acquire_next_swapchain_image(rx::memory::allocator* allocator = nullptr) = 0;
 
         /*!
          * \brief Presents the specified swapchain image
@@ -44,8 +43,8 @@ namespace nova::renderer::rhi {
         // Arrays of the per-frame swapchain resources. Each swapchain implementation is responsible for filling these arrays with
         // API-specific objects
 
-        std::vector<Framebuffer*> framebuffers;
-        std::vector<Image*> swapchain_images;
-        std::vector<Fence*> fences;
+        rx::vector<Framebuffer*> framebuffers;
+        rx::vector<Image*> swapchain_images;
+        rx::vector<Fence*> fences;
     };
 } // namespace nova::renderer::rhi

--- a/src/rhi/render_device.cpp
+++ b/src/rhi/render_device.cpp
@@ -1,17 +1,11 @@
 #include "nova_renderer/rhi/render_device.hpp"
 
-#include <utility>
-
 namespace nova::renderer::rhi {
     Swapchain* RenderDevice::get_swapchain() const { return swapchain; }
 
-    mem::AllocatorHandle<>* RenderDevice::get_allocator() const {
-        return &internal_allocator;
-    }
+    rx::memory::allocator* RenderDevice::get_allocator() const { return internal_allocator; }
 
-    RenderDevice::RenderDevice(mem::AllocatorHandle<>& allocator,
-                               NovaSettingsAccessManager& settings,
-                               NovaWindow& window)
+    RenderDevice::RenderDevice(NovaSettingsAccessManager& settings, NovaWindow& window, rx::memory::allocator* allocator)
         : settings(settings),
           internal_allocator(allocator),
           window(window),

--- a/src/rhi/swapchain.cpp
+++ b/src/rhi/swapchain.cpp
@@ -3,11 +3,11 @@
 namespace nova::renderer::rhi {
     Swapchain::Swapchain(const uint32_t num_images, const glm::uvec2& size) : num_images(num_images), size(size) {}
 
-    Framebuffer* Swapchain::get_framebuffer(const uint32_t frame_idx) const { return framebuffers.at(frame_idx); }
+    Framebuffer* Swapchain::get_framebuffer(const uint32_t frame_idx) const { return framebuffers[frame_idx]; }
 
-    Image* Swapchain::get_image(const uint32_t frame_idx) const { return swapchain_images.at(frame_idx); }
+    Image* Swapchain::get_image(const uint32_t frame_idx) const { return swapchain_images[frame_idx]; }
 
-    Fence* Swapchain::get_fence(const uint32_t frame_idx) const { return fences.at(frame_idx); }
+    Fence* Swapchain::get_fence(const uint32_t frame_idx) const { return fences[frame_idx]; }
 
     glm::uvec2 Swapchain::get_size() const { return size; }
 } // namespace nova::renderer::rhi

--- a/src/rhi/vulkan/vk_structs.hpp
+++ b/src/rhi/vulkan/vk_structs.hpp
@@ -52,7 +52,7 @@ namespace nova::renderer::rhi {
          *
          * The index in the vector is the index of the set
          */
-        std::pmr::vector<VkDescriptorSetLayout> layouts_by_set;
+        rx::vector<VkDescriptorSetLayout> layouts_by_set;
     };
 
     struct VulkanPipeline : Pipeline {
@@ -77,10 +77,10 @@ namespace nova::renderer::rhi {
 
     struct VulkanGpuInfo {
         VkPhysicalDevice phys_device{};
-        std::pmr::vector<VkQueueFamilyProperties> queue_family_props;
-        std::pmr::vector<VkExtensionProperties> available_extensions;
+        rx::vector<VkQueueFamilyProperties> queue_family_props;
+        rx::vector<VkExtensionProperties> available_extensions;
         VkSurfaceCapabilitiesKHR surface_capabilities{};
-        std::pmr::vector<VkSurfaceFormatKHR> surface_formats;
+        rx::vector<VkSurfaceFormatKHR> surface_formats;
         VkPhysicalDeviceProperties props{};
         VkPhysicalDeviceFeatures supported_features{};
         VkPhysicalDeviceMemoryProperties memory_properties{};

--- a/src/rhi/vulkan/vulkan_command_list.hpp
+++ b/src/rhi/vulkan/vulkan_command_list.hpp
@@ -20,7 +20,7 @@ namespace nova::renderer::rhi {
 
         void resource_barriers(PipelineStage stages_before_barrier,
                                PipelineStage stages_after_barrier,
-                               const std::pmr::vector<ResourceBarrier>& barriers) override;
+                               const rx::vector<ResourceBarrier>& barriers) override;
 
         void copy_buffer(Buffer* destination_buffer,
                          mem::Bytes destination_offset,
@@ -28,7 +28,7 @@ namespace nova::renderer::rhi {
                          mem::Bytes source_offset,
                          mem::Bytes num_bytes) override;
 
-        void execute_command_lists(const std::pmr::vector<CommandList*>& lists) override;
+        void execute_command_lists(const rx::vector<CommandList*>& lists) override;
 
         void begin_renderpass(Renderpass* renderpass, Framebuffer* framebuffer) override;
 
@@ -36,10 +36,9 @@ namespace nova::renderer::rhi {
 
         void bind_pipeline(const Pipeline* pipeline) override;
 
-        void bind_descriptor_sets(const std::pmr::vector<DescriptorSet*>& descriptor_sets,
-                                  const PipelineInterface* pipeline_interface) override;
+        void bind_descriptor_sets(const rx::vector<DescriptorSet*>& descriptor_sets, const PipelineInterface* pipeline_interface) override;
 
-        void bind_vertex_buffers(const std::pmr::vector<Buffer*>& buffers) override;
+        void bind_vertex_buffers(const rx::vector<Buffer*>& buffers) override;
 
         void bind_index_buffer(const Buffer* buffer) override;
 
@@ -49,6 +48,7 @@ namespace nova::renderer::rhi {
 
         void upload_data_to_image(
             Image* image, size_t width, size_t height, size_t bytes_per_pixel, Buffer* staging_buffer, const void* data) override;
+
     private:
         const VulkanRenderDevice& render_device;
     };

--- a/src/rhi/vulkan/vulkan_render_device.cpp
+++ b/src/rhi/vulkan/vulkan_render_device.cpp
@@ -882,7 +882,8 @@ namespace nova::renderer::rhi {
         // TODO: heap_mappings doesn't have the buffer's memory in it
         // Alternately, the buffer's memory isn't in heap_mappings
         // Something something assuming constantly mapped?
-        uint8_t* mapped_bytes = static_cast<uint8_t*>(*heap_mappings.find(memory->memory)) + allocation_info.offset.b_count() + offset.b_count();
+        uint8_t* mapped_bytes = static_cast<uint8_t*>(*heap_mappings.find(memory->memory)) + allocation_info.offset.b_count() +
+                                offset.b_count();
         memcpy(mapped_bytes, data, num_bytes.b_count());
     }
 
@@ -1378,9 +1379,6 @@ namespace nova::renderer::rhi {
         const auto extension_name_matcher = [](const char* ext_name) {
             return [=](const VkExtensionProperties& ext_props) -> bool { return std::strcmp(ext_name, ext_props.extensionName) == 0; };
         };
-
-        // TODO: use std::bind_front instead of std::bind when C++20 drops
-        using namespace std::placeholders;
 
         // TODO: Update as more GPUs support hardware raytracing
         info.supports_raytracing = available_extensions.find_if(extension_name_matcher(VK_NV_RAY_TRACING_EXTENSION_NAME)) !=

--- a/src/rhi/vulkan/vulkan_render_device.cpp
+++ b/src/rhi/vulkan/vulkan_render_device.cpp
@@ -1576,7 +1576,7 @@ namespace nova::renderer::rhi {
 
         rx::map<uint32_t, VkCommandPool> pools_by_queue(internal_allocator);
 
-        for(const uint32_t queue_index : queue_indices) {
+        queue_indices.each_fwd([&](const uint32_t queue_index) {
             VkCommandPoolCreateInfo command_pool_create_info;
             command_pool_create_info.sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO;
             command_pool_create_info.pNext = nullptr;
@@ -1586,7 +1586,7 @@ namespace nova::renderer::rhi {
             VkCommandPool command_pool;
             NOVA_CHECK_RESULT(vkCreateCommandPool(device, &command_pool_create_info, nullptr, &command_pool));
             pools_by_queue.insert(queue_index, command_pool);
-        }
+        });
 
         return pools_by_queue;
     }

--- a/src/rhi/vulkan/vulkan_render_device.hpp
+++ b/src/rhi/vulkan/vulkan_render_device.hpp
@@ -14,6 +14,11 @@ namespace nova::renderer::rhi {
         uint64_t max_uniform_buffer_size = 0;
     };
 
+    struct VulkanInputAssemblerLayout {
+        rx::vector<VkVertexInputAttributeDescription> attributes;
+        rx::vector<VkVertexInputBindingDescription> bindings;
+    };
+
     /*!
      * \brief Vulkan implementation of a render engine
      */
@@ -42,9 +47,7 @@ namespace nova::renderer::rhi {
         PFN_vkDestroyDebugReportCallbackEXT vkDestroyDebugReportCallbackEXT = nullptr;
         PFN_vkSetDebugUtilsObjectNameEXT vkSetDebugUtilsObjectNameEXT = nullptr;
 
-        VulkanRenderDevice(NovaSettingsAccessManager& settings,
-                           NovaWindow& window,
-                           mem::AllocatorHandle<>& allocator);
+        VulkanRenderDevice(NovaSettingsAccessManager& settings, NovaWindow& window, rx::memory::allocator* allocator);
 
         VulkanRenderDevice(VulkanRenderDevice&& old) noexcept = delete;
         VulkanRenderDevice& operator=(VulkanRenderDevice&& old) noexcept = delete;
@@ -60,81 +63,80 @@ namespace nova::renderer::rhi {
         ntl::Result<DeviceMemory*> allocate_device_memory(mem::Bytes size,
                                                           MemoryUsage usage,
                                                           ObjectType allowed_objects,
-                                                          mem::AllocatorHandle<>& allocator) override;
+                                                          rx::memory::allocator* allocator) override;
 
         ntl::Result<Renderpass*> create_renderpass(const shaderpack::RenderPassCreateInfo& data,
                                                    const glm::uvec2& framebuffer_size,
-                                                   mem::AllocatorHandle<>& allocator) override;
+                                                   rx::memory::allocator* allocator) override;
 
         Framebuffer* create_framebuffer(const Renderpass* renderpass,
-                                        const std::pmr::vector<Image*>& color_attachments,
-                                        const std::optional<Image*> depth_attachment,
+                                        const rx::vector<Image*>& color_attachments,
+                                        const rx::optional<Image*> depth_attachment,
                                         const glm::uvec2& framebuffer_size,
-                                        mem::AllocatorHandle<>& allocator) override;
+                                        rx::memory::allocator* allocator) override;
 
-        ntl::Result<PipelineInterface*> create_pipeline_interface(
-            const std::unordered_map<std::string, ResourceBindingDescription>& bindings,
-            const std::pmr::vector<shaderpack::TextureAttachmentInfo>& color_attachments,
-            const std::optional<shaderpack::TextureAttachmentInfo>& depth_texture,
-            mem::AllocatorHandle<>& allocator) override;
+        ntl::Result<PipelineInterface*> create_pipeline_interface(const rx::map<rx::string, ResourceBindingDescription>& bindings,
+                                                                  const rx::vector<shaderpack::TextureAttachmentInfo>& color_attachments,
+                                                                  const rx::optional<shaderpack::TextureAttachmentInfo>& depth_texture,
+                                                                  rx::memory::allocator* allocator) override;
 
         DescriptorPool* create_descriptor_pool(uint32_t num_sampled_images,
                                                uint32_t num_samplers,
                                                uint32_t num_uniform_buffers,
-                                               mem::AllocatorHandle<>& allocator) override;
+                                               rx::memory::allocator* allocator) override;
 
-        std::pmr::vector<DescriptorSet*> create_descriptor_sets(const PipelineInterface* pipeline_interface,
-                                                                DescriptorPool* pool,
-                                                                mem::AllocatorHandle<>& allocator) override;
+        rx::vector<DescriptorSet*> create_descriptor_sets(const PipelineInterface* pipeline_interface,
+                                                          DescriptorPool* pool,
+                                                          rx::memory::allocator* allocator) override;
 
-        void update_descriptor_sets(std::pmr::vector<DescriptorSetWrite>& writes) override;
+        void update_descriptor_sets(rx::vector<DescriptorSetWrite>& writes) override;
 
         ntl::Result<Pipeline*> create_pipeline(PipelineInterface* pipeline_interface,
                                                const shaderpack::PipelineCreateInfo& data,
-                                               mem::AllocatorHandle<>& allocator) override;
+                                               rx::memory::allocator* allocator) override;
 
-        Buffer* create_buffer(const BufferCreateInfo& info, DeviceMemoryResource& memory, mem::AllocatorHandle<>& allocator) override;
+        Buffer* create_buffer(const BufferCreateInfo& info, DeviceMemoryResource& memory, rx::memory::allocator* allocator) override;
 
         void write_data_to_buffer(const void* data, mem::Bytes num_bytes, mem::Bytes offset, const Buffer* buffer) override;
 
-        Image* create_image(const shaderpack::TextureCreateInfo& info, mem::AllocatorHandle<>& allocator) override;
+        Image* create_image(const shaderpack::TextureCreateInfo& info, rx::memory::allocator* allocator) override;
 
-        Semaphore* create_semaphore(mem::AllocatorHandle<>& allocator) override;
+        Semaphore* create_semaphore(rx::memory::allocator* allocator) override;
 
-        std::pmr::vector<Semaphore*> create_semaphores(uint32_t num_semaphores, mem::AllocatorHandle<>& allocator) override;
+        rx::vector<Semaphore*> create_semaphores(uint32_t num_semaphores, rx::memory::allocator* allocator) override;
 
-        Fence* create_fence(mem::AllocatorHandle<>& allocator, bool signaled = false) override;
+        Fence* create_fence(bool signaled, rx::memory::allocator* allocator) override;
 
-        std::pmr::vector<Fence*> create_fences(mem::AllocatorHandle<>& allocator, uint32_t num_fences, bool signaled = false) override;
+        rx::vector<Fence*> create_fences(uint32_t num_fences, bool signaled, rx::memory::allocator* allocator) override;
 
-        void wait_for_fences(std::pmr::vector<Fence*> fences) override;
+        void wait_for_fences(rx::vector<Fence*> fences) override;
 
-        void reset_fences(const std::pmr::vector<Fence*>& fences) override;
+        void reset_fences(const rx::vector<Fence*>& fences) override;
 
-        void destroy_renderpass(Renderpass* pass, mem::AllocatorHandle<>& allocator) override;
+        void destroy_renderpass(Renderpass* pass, rx::memory::allocator* allocator) override;
 
-        void destroy_framebuffer(Framebuffer* framebuffer, mem::AllocatorHandle<>& allocator) override;
+        void destroy_framebuffer(Framebuffer* framebuffer, rx::memory::allocator* allocator) override;
 
-        void destroy_pipeline_interface(PipelineInterface* pipeline_interface, mem::AllocatorHandle<>& allocator) override;
+        void destroy_pipeline_interface(PipelineInterface* pipeline_interface, rx::memory::allocator* allocator) override;
 
-        void destroy_pipeline(Pipeline* pipeline, mem::AllocatorHandle<>& allocator) override;
+        void destroy_pipeline(Pipeline* pipeline, rx::memory::allocator* allocator) override;
 
-        void destroy_texture(Image* resource, mem::AllocatorHandle<>& allocator) override;
+        void destroy_texture(Image* resource, rx::memory::allocator* allocator) override;
 
-        void destroy_semaphores(std::pmr::vector<Semaphore*>& semaphores, mem::AllocatorHandle<>& allocator) override;
+        void destroy_semaphores(rx::vector<Semaphore*>& semaphores, rx::memory::allocator* allocator) override;
 
-        void destroy_fences(const std::pmr::vector<Fence*>& fences, mem::AllocatorHandle<>& allocator) override;
+        void destroy_fences(const rx::vector<Fence*>& fences, rx::memory::allocator* allocator) override;
 
-        CommandList* create_command_list(mem::AllocatorHandle<>& allocator,
-                                         uint32_t thread_idx,
+        CommandList* create_command_list(uint32_t thread_idx,
                                          QueueType needed_queue_type,
-                                         CommandList::Level level) override;
+                                         CommandList::Level level,
+                                         rx::memory::allocator* allocator) override;
 
         void submit_command_list(CommandList* cmds,
                                  QueueType queue,
                                  Fence* fence_to_signal = nullptr,
-                                 const std::pmr::vector<Semaphore*>& wait_semaphores = {},
-                                 const std::pmr::vector<Semaphore*>& signal_semaphores = {}) override;
+                                 const rx::vector<Semaphore*>& wait_semaphores = {},
+                                 const rx::vector<Semaphore*>& signal_semaphores = {}) override;
 #pragma endregion
 
         [[nodiscard]] uint32_t get_queue_family_index(QueueType type) const;
@@ -148,14 +150,14 @@ namespace nova::renderer::rhi {
         /*!
          * The index in the vector is the thread index, the key in the map is the queue family index
          */
-        std::pmr::vector<std::pmr::unordered_map<uint32_t, VkCommandPool>> command_pools_by_thread_idx;
+        rx::vector<rx::map<uint32_t, VkCommandPool>> command_pools_by_thread_idx;
 
         /*!
          * \brief Keeps track of how much has been allocated from each heap
          *
          * In the same order as VulkanGpuInfo::memory_properties::memoryHeaps
          */
-        std::pmr::vector<uint32_t> heap_usages;
+        rx::vector<uint32_t> heap_usages;
 
         /*!
          * \brief Map from HOST_VISIBLE memory allocations to the memory address they're mapped to
@@ -163,10 +165,10 @@ namespace nova::renderer::rhi {
          * The Vulkan render engine maps memory when it's allocated, if the memory is for a uniform or a staging
          * buffer.
          */
-        std::unordered_map<VkDeviceMemory, void*> heap_mappings;
+        rx::map<VkDeviceMemory, void*> heap_mappings;
 
 #pragma region Initialization
-        std::pmr::vector<const char*> enabled_layer_names;
+        rx::vector<const char*> enabled_layer_names;
 
         void create_instance();
 
@@ -181,13 +183,13 @@ namespace nova::renderer::rhi {
 
         void create_device_and_queues();
 
-        bool does_device_support_extensions(VkPhysicalDevice device, const std::pmr::vector<char*>& required_device_extensions);
+        bool does_device_support_extensions(VkPhysicalDevice device, const rx::vector<char*>& required_device_extensions);
 
         void create_swapchain();
 
         void create_per_thread_command_pools();
 
-        [[nodiscard]] std::pmr::unordered_map<uint32_t, VkCommandPool> make_new_command_pools() const;
+        [[nodiscard]] rx::map<uint32_t, VkCommandPool> make_new_command_pools() const;
 #pragma endregion
 
 #pragma region Helpers
@@ -205,10 +207,10 @@ namespace nova::renderer::rhi {
          */
         [[nodiscard]] uint32_t find_memory_type_with_flags(uint32_t search_flags, MemorySearchMode search_mode = MemorySearchMode::Fuzzy);
 
-        [[nodiscard]] std::optional<VkShaderModule> create_shader_module(const std::pmr::vector<uint32_t>& spirv) const;
+        [[nodiscard]] rx::optional<VkShaderModule> create_shader_module(const rx::vector<uint32_t>& spirv) const;
 
-        [[nodiscard]] std::pmr::vector<VkDescriptorSetLayout> create_descriptor_set_layouts(
-            const std::unordered_map<std::string, ResourceBindingDescription>& all_bindings, mem::AllocatorHandle<>& allocator) const;
+        [[nodiscard]] rx::vector<VkDescriptorSetLayout> create_descriptor_set_layouts(
+            const rx::map<rx::string, ResourceBindingDescription>& all_bindings, rx::memory::allocator* allocator) const;
 
         /*!
          * \brief Gets the image view associated with the given image
@@ -224,9 +226,7 @@ namespace nova::renderer::rhi {
 
         [[nodiscard]] static VkCommandBufferLevel to_vk_command_buffer_level(CommandList::Level level);
 
-        [[nodiscard]] static std::tuple<std::pmr::vector<VkVertexInputAttributeDescription>,
-                                        std::pmr::vector<VkVertexInputBindingDescription>>
-        get_input_assembler_setup(const std::pmr::vector<VertexField>& vertex_fields);
+        [[nodiscard]] static VulkanInputAssemblerLayout get_input_assembler_setup(const rx::vector<VertexField>& vertex_fields);
 #pragma endregion
 
 #pragma region Debugging

--- a/src/rhi/vulkan/vulkan_swapchain.cpp
+++ b/src/rhi/vulkan/vulkan_swapchain.cpp
@@ -1,8 +1,3 @@
-/*!
- * \author ddubois
- * \date 28-Apr-18.
- */
-
 #include "vulkan_swapchain.hpp"
 
 #include "nova_renderer/util/logger.hpp"
@@ -18,21 +13,20 @@ namespace nova::renderer::rhi {
     VulkanSwapchain::VulkanSwapchain(const uint32_t num_swapchain_images,
                                      VulkanRenderDevice* render_device,
                                      const glm::uvec2 window_dimensions,
-                                     const std::pmr::vector<VkPresentModeKHR>& present_modes)
+                                     const rx::vector<VkPresentModeKHR>& present_modes)
         : Swapchain(num_swapchain_images, window_dimensions), render_device(render_device), num_swapchain_images(num_swapchain_images) {
 
         create_swapchain(num_swapchain_images, present_modes, window_dimensions);
 
-        std::pmr::vector<VkImage> vk_images = get_swapchain_images();
+        rx::vector<VkImage> vk_images = get_swapchain_images();
 
-        if(vk_images.empty()) {
+        if(vk_images.size() == 0) {
             NOVA_LOG(FATAL) << "The swapchain returned zero images";
         }
 
         swapchain_image_layouts.resize(num_swapchain_images);
-        for(auto& swapchain_image_layout : swapchain_image_layouts) {
-            swapchain_image_layout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
-        }
+        swapchain_image_layouts.each_fwd(
+            [&](VkImageLayout& swapchain_image_layout) { swapchain_image_layout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR; });
 
         // Create a dummy renderpass that writes to a single color attachment - the swapchain
         const VkRenderPass renderpass = create_dummy_renderpass();
@@ -40,7 +34,7 @@ namespace nova::renderer::rhi {
         const glm::uvec2 swapchain_size = {swapchain_extent.width, swapchain_extent.height};
 
         for(uint32_t i = 0; i < num_swapchain_images; i++) {
-            create_resources_for_frame(vk_images.at(i), renderpass, swapchain_size);
+            create_resources_for_frame(vk_images[i], renderpass, swapchain_size);
         }
 
         vkDestroyRenderPass(render_device->device, renderpass, nullptr);
@@ -49,8 +43,8 @@ namespace nova::renderer::rhi {
         transition_swapchain_images_into_color_attachment_layout(vk_images);
     }
 
-    uint8_t VulkanSwapchain::acquire_next_swapchain_image(mem::AllocatorHandle<>& allocator) {
-        auto* fence = render_device->create_fence(allocator);
+    uint8_t VulkanSwapchain::acquire_next_swapchain_image(rx::memory::allocator* allocator) {
+        auto* fence = render_device->create_fence(false, allocator);
         auto* vk_fence = static_cast<VulkanFence*>(fence);
 
         uint32_t acquired_image_idx;
@@ -70,7 +64,9 @@ namespace nova::renderer::rhi {
         }
 
         // Block until we have the swapchain image in order to mimic D3D12. TODO: Reevaluate this decision
-        render_device->wait_for_fences({vk_fence});
+        rx::vector<Fence*> fences;
+        fences.push_back(vk_fence);
+        render_device->wait_for_fences(fences);
 
         return static_cast<uint8_t>(acquired_image_idx);
     }
@@ -90,11 +86,11 @@ namespace nova::renderer::rhi {
         vkQueuePresentKHR(render_device->graphics_queue, &present_info);
     }
 
-    void VulkanSwapchain::transition_swapchain_images_into_color_attachment_layout(const std::pmr::vector<VkImage>& images) const {
-        std::pmr::vector<VkImageMemoryBarrier> barriers;
+    void VulkanSwapchain::transition_swapchain_images_into_color_attachment_layout(const rx::vector<VkImage>& images) const {
+        rx::vector<VkImageMemoryBarrier> barriers;
         barriers.reserve(images.size());
 
-        for(const VkImage& image : images) {
+        images.each_fwd([&](const VkImage& image) {
             VkImageMemoryBarrier barrier = {};
             barrier.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
             barrier.srcQueueFamilyIndex = render_device->graphics_family_index;
@@ -112,7 +108,7 @@ namespace nova::renderer::rhi {
             barrier.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
 
             barriers.push_back(barrier);
-        }
+        });
 
         VkCommandPool command_pool;
 
@@ -167,23 +163,21 @@ namespace nova::renderer::rhi {
     }
 
     void VulkanSwapchain::deinit() {
-        for(const Image* i : swapchain_images) {
+        swapchain_images.each_fwd([&](const Image* i) {
             const VulkanImage* vk_image = static_cast<const VulkanImage*>(i);
             vkDestroyImage(render_device->device, vk_image->image, nullptr);
             delete i;
-        }
+        });
         swapchain_images.clear();
 
-        for(const VkImageView& iv : swapchain_image_views) {
-            vkDestroyImageView(render_device->device, iv, nullptr);
-        }
+        swapchain_image_views.each_fwd([&](const VkImageView& iv) { vkDestroyImageView(render_device->device, iv, nullptr); });
         swapchain_image_views.clear();
 
-        for(const Fence* f : fences) {
+        fences.each_fwd([&](const Fence* f) {
             const VulkanFence* vk_fence = static_cast<const VulkanFence*>(f);
             vkDestroyFence(render_device->device, vk_fence->fence, nullptr);
             delete f;
-        }
+        });
         fences.clear();
     }
 
@@ -195,7 +189,7 @@ namespace nova::renderer::rhi {
 
     VkFormat VulkanSwapchain::get_swapchain_format() const { return swapchain_format; }
 
-    VkSurfaceFormatKHR VulkanSwapchain::choose_surface_format(const std::pmr::vector<VkSurfaceFormatKHR>& formats) {
+    VkSurfaceFormatKHR VulkanSwapchain::choose_surface_format(const rx::vector<VkSurfaceFormatKHR>& formats) {
         VkSurfaceFormatKHR result;
 
         if(formats.size() == 1 && formats[0].format == VK_FORMAT_UNDEFINED) {
@@ -205,25 +199,25 @@ namespace nova::renderer::rhi {
         }
 
         // We want 32 bit rgba and srgb nonlinear... I think? Will have to read up on it more and figure out what's up
-        for(auto& fmt : formats) {
+        formats.each_fwd([&](VkSurfaceFormatKHR& fmt) {
             if(fmt.format == VK_FORMAT_B8G8R8A8_UNORM && fmt.colorSpace == VK_COLOR_SPACE_SRGB_NONLINEAR_KHR) {
                 return fmt;
             }
-        }
+        });
 
         // We can't have what we want, so I guess we'll just use what we got
         return formats[0];
     }
 
-    VkPresentModeKHR VulkanSwapchain::choose_present_mode(const std::pmr::vector<VkPresentModeKHR>& modes) {
+    VkPresentModeKHR VulkanSwapchain::choose_present_mode(const rx::vector<VkPresentModeKHR>& modes) {
         const VkPresentModeKHR desired_mode = VK_PRESENT_MODE_MAILBOX_KHR;
 
         // Mailbox mode is best mode (also not sure why)
-        for(auto& mode : modes) {
+        modes.each_fwd([&](auto& mode) {
             if(mode == desired_mode) {
                 return desired_mode;
             }
-        }
+        });
 
         // FIFO, like FIFA, is forever
         return VK_PRESENT_MODE_FIFO_KHR;
@@ -243,7 +237,7 @@ namespace nova::renderer::rhi {
     }
 
     void VulkanSwapchain::create_swapchain(const uint32_t requested_num_swapchain_images,
-                                           const std::pmr::vector<VkPresentModeKHR>& present_modes,
+                                           const rx::vector<VkPresentModeKHR>& present_modes,
                                            const glm::uvec2& window_dimensions) {
 
         const auto surface_format = choose_surface_format(render_device->gpu.surface_formats);
@@ -335,8 +329,8 @@ namespace nova::renderer::rhi {
         fences.push_back(new VulkanFence{{}, fence});
     }
 
-    std::pmr::vector<VkImage> VulkanSwapchain::get_swapchain_images() {
-        std::pmr::vector<VkImage> vk_images;
+    rx::vector<VkImage> VulkanSwapchain::get_swapchain_images() {
+        rx::vector<VkImage> vk_images;
 
         vkGetSwapchainImagesKHR(render_device->device, swapchain, &num_swapchain_images, nullptr);
         vk_images.resize(num_swapchain_images);
@@ -349,7 +343,7 @@ namespace nova::renderer::rhi {
                 VkDebugUtilsObjectNameInfoEXT object_name = {};
                 object_name.sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_OBJECT_NAME_INFO_EXT;
                 object_name.objectType = VK_OBJECT_TYPE_IMAGE;
-                object_name.objectHandle = reinterpret_cast<uint64_t>(vk_images.at(i));
+                object_name.objectHandle = reinterpret_cast<uint64_t>(vk_images[i]);
                 object_name.pObjectName = image_name.c_str();
                 NOVA_CHECK_RESULT(render_device->vkSetDebugUtilsObjectNameEXT(render_device->device, &object_name));
             }

--- a/src/rhi/vulkan/vulkan_swapchain.cpp
+++ b/src/rhi/vulkan/vulkan_swapchain.cpp
@@ -213,7 +213,7 @@ namespace nova::renderer::rhi {
         const VkPresentModeKHR desired_mode = VK_PRESENT_MODE_MAILBOX_KHR;
 
         // Mailbox mode is best mode (also not sure why)
-        modes.each_fwd([&](auto& mode) {
+        modes.each_fwd([&](VkPresentModeKHR& mode) {
             if(mode == desired_mode) {
                 return desired_mode;
             }

--- a/src/rhi/vulkan/vulkan_swapchain.hpp
+++ b/src/rhi/vulkan/vulkan_swapchain.hpp
@@ -1,15 +1,7 @@
-/*!
- * \author ddubois
- * \date 28-Apr-18.
- */
-
-#ifndef NOVA_RENDERER_FRAMEBUFFER_MANAGER_H
-#define NOVA_RENDERER_FRAMEBUFFER_MANAGER_H
-
-#include <cstdint>
-#include <vector>
+#pragma once
 
 #include <glm/glm.hpp>
+#include <stdint.h>
 #include <vulkan/vulkan.h>
 
 #include "nova_renderer/rhi/swapchain.hpp"
@@ -33,10 +25,10 @@ namespace nova::renderer::rhi {
         VulkanSwapchain(uint32_t num_swapchain_images,
                         VulkanRenderDevice* render_device,
                         glm::uvec2 window_dimensions,
-                        const std::pmr::vector<VkPresentModeKHR>& present_modes);
+                        const rx::vector<VkPresentModeKHR>& present_modes);
 
 #pragma region Swapchain implementation
-        uint8_t acquire_next_swapchain_image(mem::AllocatorHandle<>& allocator) override;
+        uint8_t acquire_next_swapchain_image(rx::memory::allocator* allocator) override;
 
         void present(uint32_t image_idx) override;
 #pragma endregion
@@ -58,15 +50,15 @@ namespace nova::renderer::rhi {
         VkPresentModeKHR present_mode;
         VkFormat swapchain_format;
 
-        std::pmr::vector<VkImageView> swapchain_image_views;
-        std::pmr::vector<VkImageLayout> swapchain_image_layouts;
+        rx::vector<VkImageView> swapchain_image_views;
+        rx::vector<VkImageLayout> swapchain_image_layouts;
 
         uint32_t num_swapchain_images;
 
 #pragma region Initialization
-        static VkSurfaceFormatKHR choose_surface_format(const std::pmr::vector<VkSurfaceFormatKHR>& formats);
+        static VkSurfaceFormatKHR choose_surface_format(const rx::vector<VkSurfaceFormatKHR>& formats);
 
-        static VkPresentModeKHR choose_present_mode(const std::pmr::vector<VkPresentModeKHR>& modes);
+        static VkPresentModeKHR choose_present_mode(const rx::vector<VkPresentModeKHR>& modes);
 
         static VkExtent2D choose_surface_extent(const VkSurfaceCapabilitiesKHR& caps, const glm::ivec2& window_dimensions);
 
@@ -84,7 +76,7 @@ namespace nova::renderer::rhi {
          * \post swapchain_extent is set to the swapchain's actual extent
          */
         void create_swapchain(uint32_t requested_num_swapchain_images,
-                              const std::pmr::vector<VkPresentModeKHR>& present_modes,
+                              const rx::vector<VkPresentModeKHR>& present_modes,
                               const glm::uvec2& window_dimensions);
 
         /*!
@@ -92,7 +84,7 @@ namespace nova::renderer::rhi {
          *
          * \pre The swapchain exists
          */
-        std::pmr::vector<VkImage> get_swapchain_images();
+        rx::vector<VkImage> get_swapchain_images();
 
         /*!
          * \brief Creates an image view, framebuffer, and fence for a specific swapchain image
@@ -109,7 +101,7 @@ namespace nova::renderer::rhi {
         /*!
          * \brief Transitions all the provided images into COLOR_ATTACHMENT layout
          */
-        void transition_swapchain_images_into_color_attachment_layout(const std::pmr::vector<VkImage>& images) const;
+        void transition_swapchain_images_into_color_attachment_layout(const rx::vector<VkImage>& images) const;
 
         /*!
          * \brief Creates a dummy renderpass that only writes to one image - the swapchain. I need it so I can create framebuffers for the
@@ -119,5 +111,3 @@ namespace nova::renderer::rhi {
 #pragma endregion
     };
 } // namespace nova::renderer::rhi
-
-#endif // NOVA_RENDERER_FRAMEBUFFER_MANAGER_H

--- a/src/rhi/vulkan/vulkan_utils.hpp
+++ b/src/rhi/vulkan/vulkan_utils.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <string>
-#include <vector>
 
 #include "nova_renderer/rhi/command_list.hpp"
 #include "nova_renderer/shaderpack_data.hpp"


### PR DESCRIPTION
Converts the Vulkan RHI backend to use types from Rex::Core instead of the C++ standard library

This PR depends on https://github.com/NovaMods/nova-renderer/pull/240